### PR TITLE
fix(preview): address Quick Look extension review feedback

### DIFF
--- a/BlankiePresetPreview/PresetPreviewReader.swift
+++ b/BlankiePresetPreview/PresetPreviewReader.swift
@@ -17,17 +17,21 @@ enum PresetPreviewReader {
   /// artwork stays as raw `Data` here and is decoded to a `UIImage` on the main
   /// actor in the view, mirroring how the app avoids returning `UIImage` from
   /// detached work.
-  struct PresetInfo {
+  struct PresetInfo: Sendable {
     let name: String
     let creator: String?
     let soundCount: Int
     let artworkData: Data?
   }
 
-  /// Cap on a single decompressed entry. `.blankie` files are untrusted shared
-  /// input, so refuse to balloon memory on a crafted (zip-bomb) archive — the
-  /// real payloads here are a tiny JSON and a small preview image.
-  private static let maxEntryBytes = 32 * 1024 * 1024
+  /// Cap on a single decompressed *entry* — not the whole archive. The preview
+  /// only ever extracts `preset.json` (kilobytes) and one preview image (well
+  /// under a megabyte), so 8 MB clears every legitimate payload with room to
+  /// spare while refusing to balloon memory on a crafted (zip-bomb) entry. A
+  /// large `.blankie` is fine: its bulk is custom-sound audio, which the preview
+  /// never reads. The cap is kept low because this Quick Look extension runs in
+  /// a tight memory sandbox.
+  private static let maxEntryBytes = 8 * 1024 * 1024
 
   enum ReadError: Error {
     case unreadableArchive

--- a/BlankiePresetPreview/PresetPreviewView.swift
+++ b/BlankiePresetPreview/PresetPreviewView.swift
@@ -104,7 +104,7 @@ struct PresetPreviewView: View {
   }
 
   private func step(
-    number: Int, label: String, @ViewBuilder icon: () -> some View
+    number: Int, label: LocalizedStringKey, @ViewBuilder icon: () -> some View
   ) -> some View {
     HStack(spacing: 14) {
       Text("\(number)")
@@ -121,10 +121,16 @@ struct PresetPreviewView: View {
   }
 
   /// The actual Blankie app icon, from the SharedAssets catalog that both the
-  /// app and this extension build. The display asset already carries its shape,
-  /// so it renders as-is.
+  /// app and this extension build. The display asset already carries its shape.
+  /// Downsampled once to display size so this memory-constrained Quick Look
+  /// extension doesn't decode the full 1024px asset for a 30pt icon (mirrors
+  /// `AboutView.currentAppIcon`).
+  private static let appIcon: UIImage? =
+    UIImage(named: "BlankieAppIconDisplay")?
+    .preparingThumbnail(of: CGSize(width: 90, height: 90))
+
   private var appMark: some View {
-    Image("BlankieAppIconDisplay")
+    Image(uiImage: Self.appIcon ?? UIImage())
       .resizable()
       .scaledToFit()
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ A quick follow-up to 2.0 with two small additions and a handful of fixes.
 ### Added
 
 - **Quick Look preview for shared presets (iOS)** - Tap a `.blankie` file in Messages or Files and you'll see the preset's name, artwork, and sound count, plus how to add it to Blankie.
-- **Collapsible Library sections** - Collapse the Sounds and Presets lists in your Library. Blankie will remembers what you left open.
+- **Collapsible Library sections** - Collapse the Sounds and Presets lists in your Library. Blankie remembers what you left open.
 
 ### Changed
 


### PR DESCRIPTION
Quick Look preview extension fixes split out of #97 — unrelated to the iPad artwork work, addresses earlier review feedback (#96).

- `BlankiePresetPreview/PresetPreviewReader.swift`
- `BlankiePresetPreview/PresetPreviewView.swift`
- CHANGELOG grammar fix ("will remembers" → "remembers")

Targets `v2.0.2`.