### PR TITLE
feat(sounds): surface sound descriptions and localized subtitles (#106)

### DIFF
--- a/Blankie/Localizable.xcstrings
+++ b/Blankie/Localizable.xcstrings
@@ -38432,6 +38432,2022 @@
           }
         }
       }
+    },
+    "Soft, steady rainfall" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sanfter, gleichmäßiger Regen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soft, steady rainfall"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soft, steady rainfall"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lluvia suave y constante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pluie douce et régulière"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lágy, egyenletes eső"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pioggia leggera e costante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "静かに降り続く雨"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "부드럽게 이어지는 빗소리"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Miękki, miarowy deszcz"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chuva suave e constante"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yumuşak, dingin yağmur"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "轻柔平稳的雨声"
+          }
+        }
+      }
+    },
+    "Deep, rolling thunder" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tiefes, grollendes Donnern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deep, rolling thunder"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deep, rolling thunder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Truenos graves y retumbantes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tonnerre grave qui gronde"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mély, gördülő mennydörgés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tuoni cupi e profondi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "遠くで轟く雷"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "묵직하게 울리는 천둥"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Głębokie, przetaczające się grzmoty"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trovões fundos e prolongados"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Derin, yankılanan gök gürültüsü"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "低沉滚动的雷声"
+          }
+        }
+      }
+    },
+    "Whistling, rushing gusts" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pfeifende, jagende Böen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Whistling, rushing gusts"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Whistling, rushing gusts"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ráfagas que silban con fuerza"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rafales de vent sifflantes"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Süvítő, sodró széllökések"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Raffiche sibilanti e impetuose"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "口笛のように吹き抜ける風"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "휘몰아치는 바람 소리"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Świszczące, porywiste podmuchy"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rajadas de vento assobiadas"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Islık çalan, savrulan rüzgâr"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "呼啸而过的阵阵疾风"
+          }
+        }
+      }
+    },
+    "Surf rolling onto the shore" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brandung rollt ans Ufer"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Surf rolling onto the shore"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Surf rolling onto the shore"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Olas rompiendo en la orilla"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vagues déferlant sur le rivage"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Partra futó hullámok"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Onde che lambiscono la riva"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "岸に打ち寄せる波"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "해변으로 밀려드는 파도"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fale nabiegające na brzeg"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ondas a quebrar na costa"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kıyıya vuran dalgalar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "拍打上岸的海浪"
+          }
+        }
+      }
+    },
+    "Bubbling, trickling water" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Blubberndes, plätscherndes Wasser"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bubbling, trickling water"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bubbling, trickling water"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agua que borbotea y corre"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruisseau qui gargouille"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bugyogó, csörgedező víz"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Acqua che gorgoglia e scorre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "さらさらと流れる小川"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "졸졸 흐르는 시냇물"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bulgocząca, sącząca się woda"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Água a borbulhar e escorrer"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Şırıldayan, çağıldayan su"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "潺潺流淌的溪水"
+          }
+        }
+      }
+    },
+    "Morning chirping in the trees" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Morgendliches Zwitschern in den Bäumen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Morning chirping in the trees"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Morning chirping in the trees"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cantos matutinos entre los árboles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chants d'oiseaux au matin"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reggeli madárcsicsergés a fákon"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cinguettii mattutini tra gli alberi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "朝の木立に響くさえずり"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "아침 숲속의 새소리"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Poranne ćwierkanie wśród drzew"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chilreios matinais nas árvores"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ağaçlarda sabah cıvıltısı"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "林间清晨的鸟鸣"
+          }
+        }
+      }
+    },
+    "Crickets chirping in the dark" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zirpende Grillen im Dunkeln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crickets chirping in the dark"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crickets chirping in the dark"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Grillos cantando en la oscuridad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Grillons dans la nuit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tücsökciripelés a sötétben"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Grilli che friniscono nel buio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "夜に鳴く虫の声"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "밤에 우는 풀벌레 소리"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Świerszcze cykające w ciemności"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Grilos a cantar no escuro"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Karanlıkta öten cırcır böcekleri"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "夜色中的蟋蟀鸣叫"
+          }
+        }
+      }
+    },
+    "Railcars pass on nearby tracks" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Züge auf nahen Gleisen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Railcars pass on nearby tracks"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Railcars pass on nearby tracks"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vagones pasando por vías cercanas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trains passant à proximité"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vonatok a közeli síneken"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vagoni sui binari vicini"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "近くの線路を通る列車"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "가까이 지나는 기차"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pociągi na pobliskich torach"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Comboios a passar nos carris"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yakındaki raylardan geçen vagonlar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "近处轨道驶过的列车"
+          }
+        }
+      }
+    },
+    "Creaking ropes aboard a sailboat" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Knarrende Taue eines Segelboots"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creaking ropes aboard a sailboat"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creaking ropes aboard a sailboat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cabos que crujen en un velero"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cordages qui craquent sur un voilier"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nyikorgó kötelek egy vitorláson"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cime che scricchiolano su una barca a vela"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "帆船できしむロープ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "삐걱이는 돛단배 밧줄"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skrzypiące liny na żaglówce"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cordas a ranger num veleiro"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yelkenlide gıcırdayan halatlar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "帆船上吱呀的缆绳"
+          }
+        }
+      }
+    },
+    "Traffic on a busy street" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verkehr auf belebter Straße"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traffic on a busy street"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traffic on a busy street"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tráfico en una calle concurrida"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Circulation d'une rue animée"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nyüzsgő utca forgalma"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Traffico di una strada animata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "にぎやかな通りの車の音"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "번잡한 거리의 차 소리"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruch na ruchliwej ulicy"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trânsito numa rua movimentada"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "İşlek bir caddede trafik"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "繁忙街道的车流"
+          }
+        }
+      }
+    },
+    "Indistinct café chatter" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gedämpftes Café-Gemurmel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indistinct café chatter"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indistinct café chatter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Murmullo indistinto de cafetería"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rumeur feutrée d'un café"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kávézó tompa moraja"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chiacchiere indistinte al bar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "カフェのざわめき"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "웅성이는 카페 소리"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Niewyraźny gwar kawiarni"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conversa indistinta num café"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kafede belirsiz konuşmalar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "咖啡馆里模糊的交谈声"
+          }
+        }
+      }
+    },
+    "Crackling, popping logs" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Knisternde, knackende Holzscheite"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crackling, popping logs"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crackling, popping logs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Leña que crepita y chisporrotea"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Feu de bois qui crépite"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pattogó, ropogó tűz"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Legna che scoppietta e crepita"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "パチパチとはぜる薪の火"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "타닥타닥 타오르는 장작불"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trzaskające, strzelające polana"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lenha a crepitar e estalar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çıtırdayan, çatırdayan odunlar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "噼啪作响的柴火"
+          }
+        }
+      }
+    },
+    "Softer, warmer static" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Weiches, warmes rosa Rauschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Softer, warmer static"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Softer, warmer static"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruido rosa, suave y cálido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bruit rose, doux et chaud"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lágyabb, melegebb rózsaszín zaj"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rumore rosa, morbido e caldo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "柔らかく温かいピンクノイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "부드럽고 따뜻한 핑크 노이즈"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Miększy, cieplejszy różowy szum"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruído cor-de-rosa, suave e quente"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yumuşak ve sıcak pembe gürültü"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "柔和温暖的粉红噪音"
+          }
+        }
+      }
+    },
+    "Bright, steady static" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Helles, gleichmäßiges weißes Rauschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bright, steady static"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bright, steady static"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruido blanco, claro y constante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bruit blanc, clair et net"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tiszta, egyenletes fehér zaj"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rumore bianco, nitido e costante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "澄んで途切れないホワイトノイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "맑고 고른 백색소음"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jasny, równy biały szum"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruído branco, límpido e constante"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Parlak, dingin beyaz gürültü"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "明亮平稳的白噪音"
+          }
+        }
+      }
+    },
+    "Low and heavy brown noise" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tiefes, schweres braunes Rauschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low and heavy brown noise"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low and heavy brown noise"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruido marrón, grave y profundo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bruit brun, grave et profond"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mély, súlyos barna zaj"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rumore marrone, grave e profondo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "低く沈むブラウンノイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "낮고 묵직한 브라운 노이즈"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Niski, głęboki brązowy szum"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruído castanho, grave e profundo"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Derin ve ağır kahverengi gürültü"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "低沉厚重的棕色噪音"
+          }
+        }
+      }
+    },
+    "Calm, nature-like static" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruhiges, naturnahes grünes Rauschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calm, nature-like static"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calm, nature-like static"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruido verde, como la naturaleza"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bruit vert, comme la nature"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nyugodt, természetközeli zöld zaj"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rumore verde, calmo come la natura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自然に溶けるグリーンノイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "자연을 닮은 그린 노이즈"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Spokojny, naturalny zielony szum"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ruído verde, calmo como a natureza"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Doğayı andıran dingin yeşil gürültü"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "宁静自然的绿色噪音"
+          }
+        }
+      }
+    },
+    "Slow, dreamy electronic music" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Langsame, verträumte Elektromusik"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slow, dreamy electronic music"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slow, dreamy electronic music"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Música electrónica lenta y de ensueño"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Musique électronique lente et rêveuse"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lassú, álmatag elektronikus zene"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Musica elettronica lenta e sognante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ゆるやかで幻想的なアンビエント"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "느리고 몽환적인 전자음악"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wolna, senna muzyka elektroniczna"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Música eletrónica lenta e sonhadora"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yavaş, düşsel elektronik müzik"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "舒缓梦幻的电子乐"
+          }
+        }
+      }
+    },
+    "Warm, acoustic guitar" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Warme Akustikgitarre"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warm, acoustic guitar"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warm, acoustic guitar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Guitarra acústica cálida"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Guitare acoustique chaleureuse"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meleg, akusztikus gitár"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chitarra acustica e calda"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "温かなアコースティックギター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "따뜻한 어쿠스틱 기타"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ciepła gitara akustyczna"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Guitarra acústica e quente"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sıcak, akustik gitar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "温暖的原声吉他"
+          }
+        }
+      }
+    },
+    "A steady, whirring hum" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ein gleichmäßiges Surren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A steady, whirring hum"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A steady, whirring hum"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Un zumbido suave y constante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ronronnement régulier"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Egyenletes, surrogó zúgás"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Un ronzio costante e ovattato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "扇風機のうなり"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "고르게 도는 선풍기 소리"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Równomierny, wirujący pomruk"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um zumbido constante e girante"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Düzenli, uğuldayan vınıltı"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "平稳的嗡嗡声"
+          }
+        }
+      }
+    },
+    "Mellow, chill hip-hop" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sanfter, entspannter Hip-Hop"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mellow, chill hip-hop"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mellow, chill hip-hop"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hip-hop suave y relajado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hip-hop lo-fi doux et posé"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lágy, laza hip-hop"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hip-hop lo-fi e rilassato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "落ち着いたローファイ・ヒップホップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "잔잔한 로파이 힙합"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Łagodny, chillowy hip-hop"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hip-hop tranquilo e descontraído"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yumuşak, sakin hip-hop"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "舒缓慵懒的 lo-fi 节拍"
+          }
+        }
+      }
+    },
+    "Steady breeze through the pines" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sanfte Brise durch die Kiefern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steady breeze through the pines"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steady breeze through the pines"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brisa constante entre los pinos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brise régulière dans les pins"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Egyenletes szellő a fenyők közt"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brezza costante tra i pini"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "松林を抜ける風"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "솔숲을 지나는 산들바람"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Miarowy powiew wśród sosen"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brisa constante entre os pinheiros"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çamların arasında dingin esinti"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "穿过松林的微风"
+          }
+        }
+      }
+    },
+    "Mid-flight hum of an airplane cabin" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brummen der Flugzeugkabine im Flug"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mid-flight hum of an airplane cabin"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mid-flight hum of an airplane cabin"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zumbido de cabina en pleno vuelo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ronronnement d'une cabine d'avion"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Repülő utasterének zúgása"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Il ronzio della cabina in volo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "飛行中の機内のうなり"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "비행 중 기내의 웅웅거림"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Szum kabiny samolotu w locie"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zumbido da cabine em pleno voo"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uçuş sırasında kabin uğultusu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "飞行中的机舱嗡鸣"
+          }
+        }
+      }
+    },
+    "A dryer tumbling clothes" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ein Trockner mit trommelnder Wäsche"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A dryer tumbling clothes"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A dryer tumbling clothes"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Una secadora dando vueltas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sèche-linge qui tourne"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Forgó ruhaszárító"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Un'asciugatrice che gira"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "衣類を回す乾燥機"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "빨래를 돌리는 건조기"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Suszarka obracająca pranie"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Máquina a secar roupa"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çamaşır çeviren kurutma makinesi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "翻滚衣物的烘干机"
+          }
+        }
+      }
+    },
+    "A quiet, gentle lullaby" : {
+      "comment" : "A short character caption for a built-in ambient sound, shown beneath its name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ein leises, sanftes Schlaflied"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A quiet, gentle lullaby"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A quiet, gentle lullaby"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Una nana suave y tranquila"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Douce berceuse au piano"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Halk, gyengéd altatódal"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Una ninnananna dolce e delicata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "やさしいピアノの子守唄"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "잔잔하고 포근한 자장가"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cicha, delikatna kołysanka"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uma doce canção de embalar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sessiz, yumuşak bir ninni"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "静谧轻柔的摇篮曲"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Blankie/Managers/Audio/SoundCreditsManager.swift
+++ b/Blankie/Managers/Audio/SoundCreditsManager.swift
@@ -52,6 +52,10 @@ class SoundCreditsManager: ObservableObject {
     return soundDataMap[soundTitle]?.author
   }
 
+  func getSubtitle(for soundTitle: String) -> String? {
+    return soundDataMap[soundTitle]?.subtitle
+  }
+
   func getDescription(for soundTitle: String) -> String? {
     return soundDataMap[soundTitle]?.description
   }
@@ -76,6 +80,18 @@ struct ResolvedSoundCredit {
 }
 
 extension Sound {
+  /// A short character caption for this sound (e.g. "Brown noise, deep and
+  /// rumbling"), localized through the string catalog. Built-in sounds only;
+  /// custom sounds carry no subtitle. Looked up by original title so a renamed
+  /// built-in still resolves.
+  @MainActor var localizedSubtitle: String? {
+    guard !isCustom,
+      let subtitle = SoundCreditsManager.shared.getSubtitle(for: originalTitle),
+      !subtitle.isEmpty
+    else { return nil }
+    return NSLocalizedString(subtitle, comment: "Built-in sound subtitle caption")
+  }
+
   /// The credited author to display for this sound, or `nil` when there isn't
   /// one. Custom sounds use their stored credit; built-in sounds look the author
   /// up by their original title. Empty strings are treated as absent.

--- a/Blankie/Managers/Audio/SoundCreditsManager.swift
+++ b/Blankie/Managers/Audio/SoundCreditsManager.swift
@@ -67,6 +67,9 @@ class SoundCreditsManager: ObservableObject {
 
 /// A display-ready credit, resolved from sounds.json (built-in) or `CustomSoundData` (custom).
 struct ResolvedSoundCredit {
+  /// A sentence about the recording itself (built-in sounds only). Provenance
+  /// notes that pair with the source credit below them.
+  let description: String?
   let workTitle: String?
   let workUrl: URL?
   let author: String?
@@ -126,6 +129,7 @@ extension Sound {
         return nil
       }
       return ResolvedSoundCredit(
+        description: nil,
         workTitle: id3Title ?? nonEmpty(data.originalFileName),
         workUrl: sourceUrl.flatMap { URL(string: $0) },
         author: author,
@@ -137,6 +141,7 @@ extension Sound {
     guard let credit = SoundCreditsManager.shared.credits.first(where: { $0.name == originalTitle })
     else { return nil }
     return ResolvedSoundCredit(
+      description: nonEmpty(SoundCreditsManager.shared.getDescription(for: originalTitle)),
       workTitle: credit.soundName,
       workUrl: credit.soundUrl,
       author: credit.author,

--- a/Blankie/Models/CustomSoundData.swift
+++ b/Blankie/Models/CustomSoundData.swift
@@ -113,6 +113,7 @@ class CustomSoundData {
       license: "Custom",
       soundUrl: "",
       soundName: originalFileName ?? fileName,
+      subtitle: nil,
       description: nil,
       note: nil,
       lufs: detectedLUFS,

--- a/Blankie/Models/SoundData.swift
+++ b/Blankie/Models/SoundData.swift
@@ -39,6 +39,7 @@ struct SoundData: Codable {
   let license: String
   let soundUrl: String
   let soundName: String
+  let subtitle: String?
   let description: String?
   let note: String?
   let lufs: Float?

--- a/Blankie/Resources/sounds.json
+++ b/Blankie/Resources/sounds.json
@@ -25,6 +25,7 @@
       "normalizationFactor": 1.3047235,
       "soundName": "rain ambience",
       "soundUrl": "https://freesound.org/s/524605/",
+      "subtitle": "Soft, steady rainfall",
       "systemIconName": "cloud.rain",
       "title": "Rain",
       "truePeakdBTP": -0.09582323
@@ -46,6 +47,7 @@
       "normalizationFactor": 0.34687543,
       "soundName": "Infinite Storm.wav",
       "soundUrl": "https://freesound.org/s/41739",
+      "subtitle": "Deep, rolling thunder",
       "systemIconName": "cloud.bolt.rain",
       "title": "Storm",
       "truePeakdBTP": 0.20141469
@@ -74,6 +76,7 @@
       "normalizationFactor": 0.34433237,
       "soundName": "Wind blowing in a field in Texas, USA",
       "soundUrl": "https://freesound.org/s/217506/",
+      "subtitle": "Whistling, rushing gusts",
       "systemIconName": "wind",
       "title": "Wind",
       "truePeakdBTP": -0.44027612
@@ -102,6 +105,7 @@
       "normalizationFactor": 0.6328937,
       "soundName": "oceanwavescrushing.wav",
       "soundUrl": "https://freesound.org/s/48412/",
+      "subtitle": "Surf rolling onto the shore",
       "systemIconName": "water.waves",
       "title": "Waves",
       "truePeakdBTP": -1.2500726
@@ -130,6 +134,7 @@
       "normalizationFactor": 4.0023947,
       "soundName": "stream2.wav",
       "soundUrl": "https://freesound.org/s/333987/",
+      "subtitle": "Bubbling, trickling water",
       "systemIconName": "humidity",
       "title": "Stream",
       "truePeakdBTP": -15.663198
@@ -158,6 +163,7 @@
       "normalizationFactor": 4.741137,
       "soundName": "WoodThrushinMorningShawneeForestMay272012.wav",
       "soundUrl": "https://freesound.org/s/156826/",
+      "subtitle": "Morning chirping in the trees",
       "systemIconName": "bird",
       "title": "Birds",
       "truePeakdBTP": -24.517021
@@ -185,6 +191,7 @@
       "normalizationFactor": 0.22898631,
       "soundName": "Crickets Chirping At Night",
       "soundUrl": "https://soundbible.com/2083-Crickets-Chirping-At-Night.html",
+      "subtitle": "Crickets chirping in the dark",
       "systemIconName": "moon.stars.fill",
       "title": "Summer Night",
       "truePeakdBTP": -3.295281
@@ -206,6 +213,7 @@
       "normalizationFactor": 0.7667609,
       "soundName": "Trains of the Yamanote Line",
       "soundUrl": "https://freesound.org/s/259988/",
+      "subtitle": "Railcars pass on nearby tracks",
       "systemIconName": "tram.fill",
       "title": "Train",
       "truePeakdBTP": -2.109943
@@ -233,6 +241,7 @@
       "normalizationFactor": 7.943282,
       "soundName": "Ambience_Sea_Boat_Night_Ropes_4.wav",
       "soundUrl": "https://freesound.org/s/439365/",
+      "subtitle": "Creaking ropes aboard a sailboat",
       "systemIconName": "sailboat.fill",
       "title": "Boat",
       "truePeakdBTP": -25.552116
@@ -260,6 +269,7 @@
       "normalizationFactor": 3.5643487,
       "soundName": "NYC_street leve02l.wav",
       "soundUrl": "https://freesound.org/s/44796/",
+      "subtitle": "Traffic on a busy street",
       "systemIconName": "building.2",
       "title": "City",
       "truePeakdBTP": -18.747208
@@ -286,6 +296,7 @@
       "normalizationFactor": 0.5999022,
       "soundName": "Restaurant Ambiance",
       "soundUrl": "https://soundbible.com/1664-Restaurant-Ambiance.html",
+      "subtitle": "Indistinct café chatter",
       "systemIconName": "cup.and.saucer.fill",
       "title": "Coffee Shop",
       "truePeakdBTP": -8.590274
@@ -313,6 +324,7 @@
       "normalizationFactor": 7.081784,
       "soundName": "Woodstove",
       "soundUrl": "https://www.nps.gov/media/video/view.htm?id=1E69FA23-BC88-460E-8EFD-8D3BA8B06C53",
+      "subtitle": "Crackling, popping logs",
       "systemIconName": "fireplace",
       "title": "Fireplace",
       "truePeakdBTP": -1.2723314
@@ -334,6 +346,7 @@
       "normalizationFactor": 1.0217222,
       "soundName": "Pink Noise (Stereo)",
       "soundUrl": "https://blankie.rest/credits",
+      "subtitle": "Softer, warmer static",
       "systemIconName": "waveform.path",
       "title": "Pink Noise",
       "truePeakdBTP": -13.174751
@@ -355,6 +368,7 @@
       "normalizationFactor": 1.0543154,
       "soundName": "White Noise (Stereo)",
       "soundUrl": "https://blankie.rest/credits",
+      "subtitle": "Bright, steady static",
       "systemIconName": "waveform",
       "title": "White Noise",
       "truePeakdBTP": -22.625587
@@ -376,6 +390,7 @@
       "normalizationFactor": 1.0232387,
       "soundName": "Deep Noise (Stereo)",
       "soundUrl": "https://blankie.rest/credits",
+      "subtitle": "Low and heavy brown noise",
       "systemIconName": "waveform.low",
       "title": "Deep Noise",
       "truePeakdBTP": -12.099489
@@ -397,6 +412,7 @@
       "normalizationFactor": 1.0231403,
       "soundName": "Green Noise (Stereo)",
       "soundUrl": "https://blankie.rest/credits",
+      "subtitle": "Calm, nature-like static",
       "systemIconName": "waveform.mid",
       "title": "Green Noise",
       "truePeakdBTP": -16.555126
@@ -419,6 +435,7 @@
       "normalizationFactor": 0.42011017,
       "soundName": "Couple' Morning.wav",
       "soundUrl": "https://freesound.org/s/742808/",
+      "subtitle": "Slow, dreamy electronic music",
       "systemIconName": "pianokeys.inverse",
       "title": "Ambient Synth",
       "truePeakdBTP": -4.2743454
@@ -441,6 +458,7 @@
       "normalizationFactor": 0.12734462,
       "soundName": "acoustic guitar in open D",
       "soundUrl": "https://freesound.org/s/653928/",
+      "subtitle": "Warm, acoustic guitar",
       "systemIconName": "guitars.fill",
       "title": "Gentle Guitar",
       "truePeakdBTP": 1.0351397
@@ -462,6 +480,7 @@
       "normalizationFactor": 0.9935306,
       "soundName": "Air Conditioner Fan Hum.wav",
       "soundUrl": "https://freesound.org/s/515859/",
+      "subtitle": "A steady, whirring hum",
       "systemIconName": "fan.desk",
       "title": "Fan",
       "truePeakdBTP": -11.977426
@@ -484,6 +503,7 @@
       "normalizationFactor": 0.30452284,
       "soundName": "Laundry On The Wire",
       "soundUrl": "https://freemusicarchive.org/music/holiznacc0/lazy-summer-lofi-1/laundry-on-the-wiremp3/",
+      "subtitle": "Mellow, chill hip-hop",
       "systemIconName": "music.quarternote.3",
       "title": "Lo-Fi Beats",
       "truePeakdBTP": 0.15277258
@@ -505,6 +525,7 @@
       "normalizationFactor": 2.2899094,
       "soundName": "Wind_pine.wav",
       "soundUrl": "https://freesound.org/s/202989/",
+      "subtitle": "Steady breeze through the pines",
       "systemIconName": "tree.fill",
       "title": "Forest",
       "truePeakdBTP": -13.119295
@@ -527,6 +548,7 @@
       "normalizationFactor": 1.4557424,
       "soundName": "Interior airplane.WAV",
       "soundUrl": "https://freesound.org/s/133496/",
+      "subtitle": "Mid-flight hum of an airplane cabin",
       "systemIconName": "airplane",
       "title": "Airplane",
       "truePeakdBTP": -18.990189
@@ -548,6 +570,7 @@
       "normalizationFactor": 0.8052029,
       "soundName": "Laundry Room Ambience.wav",
       "soundUrl": "https://freesound.org/s/411914/",
+      "subtitle": "A dryer tumbling clothes",
       "systemIconName": "washer.fill",
       "title": "Laundry Room",
       "truePeakdBTP": -4.139728
@@ -570,6 +593,7 @@
       "normalizationFactor": 1.2054272,
       "soundName": "Sleepy Upright Piano Seamless Loop",
       "soundUrl": "https://freesound.org/people/blankie.rest/sounds/859607/",
+      "subtitle": "A quiet, gentle lullaby",
       "systemIconName": "pianokeys",
       "title": "Warm Piano",
       "truePeakdBTP": -11.317333

--- a/Blankie/UI/Components/SoloSoundIcon.swift
+++ b/Blankie/UI/Components/SoloSoundIcon.swift
@@ -93,3 +93,33 @@ struct SoloSoundIcon: View {
     .sensoryFeedback(.selection, trigger: sound.isSelected)
   }
 }
+
+/// The solo sound presented as a Now Playing card: the large icon with the
+/// sound's name and its subtitle caption beneath, mirroring the system Now
+/// Playing layout. In solo mode the mixer view itself IS the now-playing
+/// surface, so this replaces the grid rather than living in a separate sheet.
+struct SoloSoundCard: View {
+  let sound: Sound
+
+  var body: some View {
+    VStack(spacing: 16) {
+      SoloSoundIcon(sound: sound)
+
+      VStack(spacing: 4) {
+        Text(sound.localizedTitle)
+          .font(.title2)
+          .fontWeight(.semibold)
+
+        if let subtitle = sound.localizedSubtitle {
+          Text(subtitle)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .multilineTextAlignment(.center)
+      // The name and caption are shown here on the card, so hide them from
+      // VoiceOver — the icon already exposes the title as a button label.
+      .accessibilityHidden(true)
+    }
+  }
+}

--- a/Blankie/UI/Components/SoloSoundIcon.swift
+++ b/Blankie/UI/Components/SoloSoundIcon.swift
@@ -104,6 +104,10 @@ struct SoloSoundCard: View {
   var body: some View {
     VStack(spacing: 16) {
       SoloSoundIcon(sound: sound)
+        // The card's text below carries the name and subtitle to VoiceOver, so
+        // the icon is decorative here — hide it to avoid announcing the title
+        // twice while keeping the subtitle reachable.
+        .accessibilityHidden(true)
 
       VStack(spacing: 4) {
         Text(sound.localizedTitle)
@@ -117,9 +121,8 @@ struct SoloSoundCard: View {
         }
       }
       .multilineTextAlignment(.center)
-      // The name and caption are shown here on the card, so hide them from
-      // VoiceOver — the icon already exposes the title as a button label.
-      .accessibilityHidden(true)
+      // Read the name and its subtitle caption as one VoiceOver announcement.
+      .accessibilityElement(children: .combine)
     }
   }
 }

--- a/Blankie/UI/Components/SoundCreditInfoButton.swift
+++ b/Blankie/UI/Components/SoundCreditInfoButton.swift
@@ -45,34 +45,45 @@ private struct SoundCreditPopoverContent: View {
   let credit: ResolvedSoundCredit
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      // The original work's name leads; the sound's own name is already visible in the row.
-      if let workTitle = credit.workTitle {
-        linkOrText(workTitle, url: credit.workUrl, hint: Text("Opens the sound source"))
-          .font(.headline)
+    VStack(alignment: .leading, spacing: 10) {
+      if let description = credit.description {
+        Text(description)
+          .font(.callout)
+          .fixedSize(horizontal: false, vertical: true)
       }
 
-      if credit.author != nil || credit.license != nil {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-          if let author = credit.author {
-            Text("by \(author)")
-              .foregroundStyle(.secondary)
+      if credit.workTitle != nil || credit.author != nil || credit.license != nil {
+        VStack(alignment: .leading, spacing: 4) {
+          // The original work's name. The sound's display name is already visible in the row.
+          if let workTitle = credit.workTitle {
+            linkOrText(workTitle, url: credit.workUrl, hint: Text("Opens the sound source"))
+              .font(.subheadline)
+              .fontWeight(.medium)
           }
-          if credit.author != nil, credit.license != nil {
-            Text(verbatim: "·")
-              .foregroundStyle(.tertiary)
-              .accessibilityHidden(true)
-          }
-          if let license = credit.license {
-            if credit.licenseUrl != nil {
-              linkOrText(license.linkText, url: credit.licenseUrl)
-            } else {
-              Text(license.linkText)
-                .foregroundStyle(.secondary)
+
+          if credit.author != nil || credit.license != nil {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+              if let author = credit.author {
+                Text("by \(author)")
+                  .foregroundStyle(.secondary)
+              }
+              if credit.author != nil, credit.license != nil {
+                Text(verbatim: "·")
+                  .foregroundStyle(.tertiary)
+                  .accessibilityHidden(true)
+              }
+              if let license = credit.license {
+                if credit.licenseUrl != nil {
+                  linkOrText(license.linkText, url: credit.licenseUrl)
+                } else {
+                  Text(license.linkText)
+                    .foregroundStyle(.secondary)
+                }
+              }
             }
+            .font(.caption)
           }
         }
-        .font(.caption)
       }
     }
     // Fixed width keeps popovers a consistent size; text wraps instead of truncating.

--- a/Blankie/UI/Components/SoundManagementRow.swift
+++ b/Blankie/UI/Components/SoundManagementRow.swift
@@ -41,8 +41,16 @@ struct SoundManagementRowContent: View {
   }
 
   private var soundInfo: some View {
-    Text(sound.localizedTitle)
-      .foregroundColor(.primary)
+    VStack(alignment: .leading, spacing: 2) {
+      Text(sound.localizedTitle)
+        .foregroundColor(.primary)
+      if let subtitle = sound.localizedSubtitle {
+        Text(subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+    }
   }
 
   @ViewBuilder

--- a/Blankie/UI/Sheets/NowPlayingSheet.swift
+++ b/Blankie/UI/Sheets/NowPlayingSheet.swift
@@ -27,6 +27,22 @@ import SwiftUI
     @State private var showingTimer = false
     var backgroundImage: PlatformImage?
 
+    /// Rendered inline as the solo mixer's now-playing surface rather than in a
+    /// sheet: drops the drag handle and the dark sheet background so the player
+    /// content sits over the mixer's own backdrop, and hides the close chevron
+    /// (solo is left by choosing another sound or preset, not by dismissing).
+    var inline: Bool = false
+
+    /// Fired when the inline player's next/previous lands on a preset (so solo
+    /// ends). The mixer would otherwise drop back to the grid; instead it opens
+    /// the full Now Playing sheet for the preset, keeping the expanded player.
+    var onNavigateToPreset: (() -> Void)?
+
+    /// The mirror of `onNavigateToPreset`: fired when the modal sheet's
+    /// next/previous lands on a solo sound. The sheet dismisses so the inline
+    /// solo player takes over instead of the sheet showing the solo sound.
+    var onNavigateToSolo: (() -> Void)?
+
     /// CarPlay routes audio (and volume) to the car, so the in-app volume bar
     /// has nothing to control there — hide the whole row when connected.
     /// Reads AudioManager's published flag (fed by CarPlayAudioBridge).
@@ -71,57 +87,72 @@ import SwiftUI
     }
 
     var body: some View {
-      // Size to the presenting sheet (not the window): a large-detent sheet is a
-      // touch shorter than the full window, so framing to the sheet keeps the
-      // bottom controls on screen instead of clipped.
-      GeometryReader { proxy in
-        ZStack {
-          // Background fills the whole sheet. Rounded top corners show while the
-          // zoom transition is mid-flight and behind the sheet's own rounding.
-          Color.black
-            .overlay {
-              if audioManager.soloModeSound == nil && !audioManager.isQuickMix,
-                let image = backgroundImage
-              {
-                Image(uiImage: image)
-                  .resizable()
-                  .aspectRatio(contentMode: .fill)
-                  .frame(maxWidth: .infinity, maxHeight: .infinity)
-                  .clipped()
-                  .blur(radius: 40)
-                  .opacity(0.4)
-              } else {
-                LinearGradient(
-                  colors: [
-                    accentColor.opacity(0.6),
-                    accentColor.opacity(0.3),
-                    Color.black.opacity(0.8),
-                  ],
-                  startPoint: .topLeading,
-                  endPoint: .bottomTrailing
+      Group {
+        if inline {
+          // Inline in the solo mixer: the player content over the mixer's own
+          // backdrop, no sheet chrome. Extend into the bottom safe area like the
+          // sheet does (which ignoresSafeArea) so the shared layout's bottom
+          // spacer clears the home indicator once, not twice — otherwise the
+          // AirPlay/Timer row rides ~34pt high and won't line up with the sheet.
+          GeometryReader { proxy in
+            nowPlayingView(in: proxy.size)
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
+          }
+          .ignoresSafeArea(.container, edges: .bottom)
+        } else {
+          // Size to the presenting sheet (not the window): a large-detent sheet is
+          // a touch shorter than the full window, so framing to the sheet keeps the
+          // bottom controls on screen instead of clipped.
+          GeometryReader { proxy in
+            ZStack {
+              // Background fills the whole sheet. Rounded top corners show while the
+              // zoom transition is mid-flight and behind the sheet's own rounding.
+              Color.black
+                .overlay {
+                  if audioManager.soloModeSound == nil && !audioManager.isQuickMix,
+                    let image = backgroundImage
+                  {
+                    Image(uiImage: image)
+                      .resizable()
+                      .aspectRatio(contentMode: .fill)
+                      .frame(maxWidth: .infinity, maxHeight: .infinity)
+                      .clipped()
+                      .blur(radius: 40)
+                      .opacity(0.4)
+                  } else {
+                    LinearGradient(
+                      colors: [
+                        accentColor.opacity(0.6),
+                        accentColor.opacity(0.3),
+                        Color.black.opacity(0.8),
+                      ],
+                      startPoint: .topLeading,
+                      endPoint: .bottomTrailing
+                    )
+                  }
+                }
+                .clipShape(
+                  UnevenRoundedRectangle(
+                    topLeadingRadius: 38,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: 38,
+                    style: .continuous
+                  )
                 )
-              }
-            }
-            .clipShape(
-              UnevenRoundedRectangle(
-                topLeadingRadius: 38,
-                bottomLeadingRadius: 0,
-                bottomTrailingRadius: 0,
-                topTrailingRadius: 38,
-                style: .continuous
-              )
-            )
-            .ignoresSafeArea()
-            .accessibilityHidden(true)
+                .ignoresSafeArea()
+                .accessibilityHidden(true)
 
-          // Content stays within the top safe area so the drag handle and
-          // everything below it sit clear of the Dynamic Island.
-          expandedPlayerView(proxy.size)
-            .padding(.top, proxy.safeAreaInsets.top > 0 ? proxy.safeAreaInsets.top : 10)
+              // Content stays within the top safe area so the drag handle and
+              // everything below it sit clear of the Dynamic Island.
+              expandedPlayerView(proxy.size)
+                .padding(.top, proxy.safeAreaInsets.top > 0 ? proxy.safeAreaInsets.top : 10)
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+          }
+          .ignoresSafeArea()
         }
-        .frame(width: proxy.size.width, height: proxy.size.height)
       }
-      .ignoresSafeArea()
       .sheet(isPresented: $showingTimer) {
         // Detents and presentationSizing don't compose — when both are set the
         // detents win and presentationSizing is ignored, leaving iPad stuck at
@@ -580,7 +611,14 @@ import SwiftUI
               .foregroundColor(.white)
               .lineLimit(1)
 
-            if soloSound.isCustom, let author = soloSound.creditedAuthor {
+            // Built-in sounds carry a subtitle caption; custom sounds show their
+            // credited author instead (they have no subtitle).
+            if let subtitle = soloSound.localizedSubtitle {
+              Text(subtitle)
+                .font(.title3)
+                .foregroundColor(.white.opacity(0.7))
+                .lineLimit(1)
+            } else if soloSound.isCustom, let author = soloSound.creditedAuthor {
               Text(author)
                 .font(.title3)
                 .foregroundColor(.white.opacity(0.7))
@@ -644,6 +682,32 @@ import SwiftUI
       .padding(.horizontal, 32)
     }
 
+    /// Run a next/previous, then hand off if we've crossed between a solo sound
+    /// (inline player) and a preset (sheet), all in one non-animated transaction
+    /// so the aligned layouts swap in place instead of the sheet sliding/zooming.
+    private func performNavigation(_ navigate: () -> Void) {
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        navigate()
+        handlePostNavigation()
+      }
+    }
+
+    /// Keep next/previous consistent about where a sound "lives": solo sounds
+    /// belong to the inline player, presets to the modal sheet. After navigating,
+    /// hand off if we've crossed that line.
+    private func handlePostNavigation() {
+      if inline {
+        // Inline solo player landed on a preset → open the full sheet for it.
+        if audioManager.soloModeSound == nil { onNavigateToPreset?() }
+      } else {
+        // Modal sheet landed on a solo sound → dismiss so the solo sound's
+        // inline page takes over instead of showing it in the sheet.
+        if audioManager.soloModeSound != nil { onNavigateToSolo?() }
+      }
+    }
+
     // MARK: - Transport Controls
 
     @ViewBuilder
@@ -654,7 +718,7 @@ import SwiftUI
 
         if canNavigate {
           Button {
-            audioManager.navigateToPreviousPreset()
+            performNavigation(audioManager.navigateToPreviousPreset)
           } label: {
             Image(systemName: "backward.fill")
               .font(.system(size: 32))
@@ -680,7 +744,7 @@ import SwiftUI
 
         if canNavigate {
           Button {
-            audioManager.navigateToNextPreset()
+            performNavigation(audioManager.navigateToNextPreset)
           } label: {
             Image(systemName: "forward.fill")
               .font(.system(size: 32))
@@ -708,19 +772,22 @@ import SwiftUI
 
     private var bottomActionsContent: some View {
       HStack(spacing: 20) {
-        // Left: collapse back to the mini bar
-        Button {
-          onDismiss?()
-        } label: {
-          Image(systemName: "chevron.down")
-            .foregroundColor(.white.opacity(0.7))
-            .font(.system(size: 20, weight: .medium))
-            .frame(width: 56, height: 56)
-            .contentShape(Circle())
+        // Left: collapse back to the mini bar. Sheet only — the inline solo
+        // player has no close button (the mixer's own nav bar collapses it).
+        if !inline {
+          Button {
+            onDismiss?()
+          } label: {
+            Image(systemName: "chevron.down")
+              .foregroundColor(.white.opacity(0.7))
+              .font(.system(size: 20, weight: .medium))
+              .frame(width: 56, height: 56)
+              .contentShape(Circle())
+          }
+          .buttonStyle(.plain)
+          .accessibilityLabel(Text("Close"))
+          .modifier(NowPlayingActionGlass())
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text("Close"))
-        .modifier(NowPlayingActionGlass())
 
         // Middle: AirPlay / audio output route picker. The Playing Audio HIG
         // asks apps to permit rerouting of audio output when possible; this is

--- a/Blankie/UI/Sheets/SoundSelectionView.swift
+++ b/Blankie/UI/Sheets/SoundSelectionView.swift
@@ -105,8 +105,16 @@ struct SoundSelectionView: View {
             .accessibilityHidden(true)
 
           Label {
-            Text(sound.localizedTitle)
-              .foregroundStyle(.primary)
+            VStack(alignment: .leading, spacing: 2) {
+              Text(sound.localizedTitle)
+                .foregroundStyle(.primary)
+              if let subtitle = sound.localizedSubtitle {
+                Text(subtitle)
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+                  .lineLimit(1)
+              }
+            }
           } icon: {
             Image(systemName: sound.systemIconName)
               .foregroundStyle(isSelected ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
@@ -132,7 +140,15 @@ struct SoundSelectionView: View {
         let isRowSelected = selectedSounds.contains(sound.fileName)
 
         Label {
-          Text(sound.localizedTitle)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(sound.localizedTitle)
+            if let subtitle = sound.localizedSubtitle {
+              Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+          }
         } icon: {
           Image(systemName: sound.systemIconName)
             .foregroundStyle(isRowSelected ? AnyShapeStyle(.tint) : AnyShapeStyle(.white))

--- a/Blankie/UI/Views/ContentView.swift
+++ b/Blankie/UI/Views/ContentView.swift
@@ -162,7 +162,7 @@ import UniformTypeIdentifiers
         } else if let soloSound = soloLayoutSound {
           VStack {
             Spacer()
-            SoloSoundIcon(sound: soloSound)
+            SoloSoundCard(sound: soloSound)
               .transition(.scale.combined(with: .opacity))
             Spacer()
           }

--- a/Blankie/UI/Views/LibraryView.swift
+++ b/Blankie/UI/Views/LibraryView.swift
@@ -383,7 +383,9 @@ struct SoloPickerRow: View {
   }
 
   var body: some View {
-    HStack {
+    let subtitle = sound.localizedSubtitle
+    let a11yLabel = subtitle.map { "\(sound.localizedTitle). \($0)" } ?? sound.localizedTitle
+    return HStack {
       HStack(spacing: 10) {
         PresetThumbnail(
           artworkId: nil,
@@ -394,10 +396,19 @@ struct SoloPickerRow: View {
         )
         .accessibilityHidden(true)
 
-        Text(sound.localizedTitle)
-          .foregroundColor(
-            LibraryRowStyle.titleColor(
-              isCurrent: isCurrent, accent: accent, presentation: presentation))
+        VStack(alignment: .leading, spacing: 2) {
+          Text(sound.localizedTitle)
+            .foregroundColor(
+              LibraryRowStyle.titleColor(
+                isCurrent: isCurrent, accent: accent, presentation: presentation))
+
+          if let subtitle {
+            Text(subtitle)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+          }
+        }
 
         LibraryRowStyle.nowPlayingIndicator(
           isCurrent: isCurrent, isPlaying: audioManager.isGloballyPlaying,
@@ -413,7 +424,7 @@ struct SoloPickerRow: View {
       // Merge the row into a single element so VoiceOver exposes the tap as an
       // activation (an un-combined container drops the .onTapGesture action).
       .accessibilityElement(children: .combine)
-      .accessibilityLabel(Text(sound.localizedTitle))
+      .accessibilityLabel(Text(a11yLabel))
       .accessibilityAddTraits(.isButton)
       .accessibilityAddTraits(isCurrent ? [.isSelected] : [])
       // macOS doesn't expose .onTapGesture as a VoiceOver activation, so the
@@ -421,7 +432,7 @@ struct SoloPickerRow: View {
       // as a real Button for assistive tech; iOS gets the action via .combine.
       #if os(macOS)
         .accessibilityRepresentation {
-          Button(sound.localizedTitle) { activateRow() }
+          Button(a11yLabel) { activateRow() }
           .accessibilityAddTraits(isCurrent ? [.isSelected] : [])
         }
       #endif

--- a/Blankie/UI/Views/Mixer/MixerView+UIComponents.swift
+++ b/Blankie/UI/Views/Mixer/MixerView+UIComponents.swift
@@ -15,8 +15,11 @@ import SwiftUI
     // MARK: - Navigation Elements
 
     var navigationTitle: String {
-      if let soloSound = audioManager.soloModeSound {
-        return soloSound.localizedTitle
+      // Solo renders the full inline now-playing player, which shows the sound
+      // name under the artwork — leave the nav heading empty so it isn't shown
+      // twice.
+      if audioManager.soloModeSound != nil {
+        return ""
       }
 
       if audioManager.isQuickMix {

--- a/Blankie/UI/Views/Mixer/MixerView.swift
+++ b/Blankie/UI/Views/Mixer/MixerView.swift
@@ -81,7 +81,8 @@ private enum IPhonePage: Hashable {
         ) {
           NowPlayingSheet(
             onDismiss: { showingNowPlaying = false },
-            backgroundImage: backgroundImage
+            backgroundImage: backgroundImage,
+            onNavigateToSolo: { swapNowPlaying(showSheet: false) }
           )
         }
       )
@@ -240,7 +241,9 @@ private enum IPhonePage: Hashable {
         // this, iPad at regular horizontal size shows no play/pause at all
         // (compact width falls back to iPhoneLayout, which does include it).
         .nowPlayingBottomBar {
-          nowPlayingBar
+          if !hidesNowPlayingBarForSolo {
+            nowPlayingBar
+          }
         }
       }
       .navigationSplitViewStyle(.balanced)
@@ -267,7 +270,9 @@ private enum IPhonePage: Hashable {
       // Attached to the stack, not a page, so the bar persists across the
       // Library root and the pushed mixer.
       .nowPlayingBottomBar {
-        nowPlayingBar
+        if !hidesNowPlayingBarForSolo {
+          nowPlayingBar
+        }
       }
     }
 
@@ -277,6 +282,28 @@ private enum IPhonePage: Hashable {
     /// detail — it expands Now Playing.
     private var barShowsMixer: Bool {
       !isLargeDevice && iPhonePath.isEmpty
+    }
+
+    /// Hide the bottom mini player while the mixer is showing the big solo card
+    /// — the card already is the now-playing surface, so the bar would just echo
+    /// the same sound. It stays everywhere else: the iPhone Library root
+    /// (`barShowsMixer`), Quick Mix, and normal preset playback.
+    private var hidesNowPlayingBarForSolo: Bool {
+      soloLayoutSound != nil && !barShowsMixer
+    }
+
+    /// Cross between a solo sound (inline player) and a preset (modal sheet) via
+    /// next/previous. The two layouts are lined up, so swap instantly (no zoom or
+    /// slide) — it reads as the content simply changing rather than a full sheet
+    /// present/dismiss. When returning to a solo sound, make the mixer the page
+    /// behind the sheet so it lands on the solo sound's inline page.
+    private func swapNowPlaying(showSheet: Bool) {
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        if !showSheet { iPhonePath = [.mixer] }
+        showingNowPlaying = showSheet
+      }
     }
 
     /// Mini player pinned above the bottom safe area; the zoom transition into
@@ -411,19 +438,19 @@ private enum IPhonePage: Hashable {
 
     @ViewBuilder
     func soloModeView(for soloSound: Sound) -> some View {
-      VStack {
-        Spacer()
-        SoloSoundIcon(sound: soloSound)
-          .transition(
-            .asymmetric(
-              insertion: .scale.combined(with: .opacity),
-              removal: .scale.combined(with: .opacity)
-            )
-          )
-        Spacer()
-      }
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .padding()
+      // The solo sound IS the now-playing surface: render the full Now Playing
+      // player inline (square artwork, name, caption, transport, volume,
+      // actions) instead of a separate sheet. If next/previous navigates onto a
+      // preset (leaving solo), open the full Now Playing sheet for it rather than
+      // dropping back to the grid.
+      NowPlayingSheet(inline: true, onNavigateToPreset: { swapNowPlaying(showSheet: true) })
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Source the sheet's zoom transition from the inline solo player (the
+        // mini-player, the usual source, is hidden during solo). Presenting or
+        // dismissing the preset sheet then morphs to/from this player instead of
+        // sliding. The two are never on screen together, so the id is unambiguous.
+        .matchedTransitionSource(id: "nowPlaying", in: nowPlayingNamespace)
+        .transition(.opacity)
     }
 
     // MARK: - List View


### PR DESCRIPTION
Adds descriptions and subtitles to the sound library, plus inline solo Now Playing.

- Sound subtitles surfaced across the app and localized
- Sound descriptions added to the library UI
- Inline solo Now Playing support

Refs #106.

**Merge order:** first — merges clean against everything else targeting `release/v2.1.0`.