### PR TITLE
fix: post-merge follow-ups — widget build, Siri/Spotlight, l10n, a11y

### DIFF
--- a/Blankie.xcodeproj/project.pbxproj
+++ b/Blankie.xcodeproj/project.pbxproj
@@ -963,7 +963,7 @@
 				INFOPLIST_FILE = BlankieWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BlankieWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -974,9 +974,9 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.codybrom.blankie.BlankieWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER).BlankieWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -991,7 +991,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 26.5;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = Debug;
 		};
@@ -1014,7 +1014,7 @@
 				INFOPLIST_FILE = BlankieWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BlankieWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1025,9 +1025,9 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.codybrom.blankie.BlankieWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER).BlankieWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -1042,7 +1042,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 26.5;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = "Debug-CarPlay";
 		};
@@ -1064,7 +1064,7 @@
 				INFOPLIST_FILE = BlankieWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BlankieWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1075,9 +1075,9 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.codybrom.blankie.BlankieWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER).BlankieWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -1092,7 +1092,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 26.5;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = Release;
 		};
@@ -1114,7 +1114,7 @@
 				INFOPLIST_FILE = BlankieWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BlankieWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1125,9 +1125,9 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.codybrom.blankie.BlankieWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER).BlankieWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -1142,7 +1142,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 26.5;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = "Release-CarPlay";
 		};

--- a/Blankie/Intents/Entities/PresetEntity.swift
+++ b/Blankie/Intents/Entities/PresetEntity.swift
@@ -9,7 +9,9 @@ import AppIntents
 
 /// App Intents-facing wrapper around `Preset`, so Siri/Shortcuts can pick a
 /// preset by name without exposing the full model (artwork, sound states, etc).
-struct PresetEntity: AppEntity {
+/// `IndexedEntity` makes presets findable in Spotlight; the default index
+/// attributes are derived from `displayRepresentation` (title + icon).
+struct PresetEntity: AppEntity, IndexedEntity {
   let id: UUID
   var name: String
   var isDefault: Bool

--- a/Blankie/Intents/Entities/SoundEntity.swift
+++ b/Blankie/Intents/Entities/SoundEntity.swift
@@ -9,7 +9,9 @@ import AppIntents
 
 /// App Intents-facing wrapper around `Sound`, keyed by the sound's stable
 /// `fileName` (not its `UUID`, which is re-minted every launch).
-struct SoundEntity: AppEntity {
+/// `IndexedEntity` makes sounds findable in Spotlight; the default index
+/// attributes are derived from `displayRepresentation` (title + icon).
+struct SoundEntity: AppEntity, IndexedEntity {
   let id: String
   var title: String
   var systemIconName: String

--- a/Blankie/Intents/PlayPresetIntent.swift
+++ b/Blankie/Intents/PlayPresetIntent.swift
@@ -29,6 +29,10 @@ struct PlayPresetIntent: AppIntent, AudioPlaybackIntent {
     guard let target = PresetManager.shared.presets.first(where: { $0.id == preset.id }) else {
       throw BlankieIntentError.presetNotFound
     }
+    // Exit solo/Quick Mix first: applyPreset's sound-state application no-ops
+    // while a solo sound is active, and it never clears isQuickMix on its own —
+    // the same ritual WidgetPlayFavoriteIntent runs before applying a preset.
+    AudioManager.shared.leaveTransientModes()
     try PresetManager.shared.applyPreset(target)
     // applyPreset no-ops playback when the preset was already current, so
     // explicitly ensure it's playing regardless of prior state.

--- a/Blankie/Intents/PlaySoundIntent.swift
+++ b/Blankie/Intents/PlaySoundIntent.swift
@@ -29,6 +29,10 @@ struct PlaySoundIntent: AppIntent, AudioPlaybackIntent {
     guard let target = AudioManager.shared.sound(fileName: sound.id) else {
       throw BlankieIntentError.soundNotFound
     }
+    // Leave solo/Quick Mix so the sound is actually audible: solo suppresses a
+    // newly selected non-solo sound, and Quick Mix would otherwise stay active
+    // with its own sound set instead of the sound being added to the mix.
+    AudioManager.shared.leaveTransientModes()
     if !target.isSelected {
       target.isSelected = true
     }

--- a/Blankie/Localizable.xcstrings
+++ b/Blankie/Localizable.xcstrings
@@ -9808,8 +9808,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktuelle"
+            "state" : "needs_review",
+            "value" : "Aktuell"
           }
         },
         "en-GB" : {
@@ -11982,8 +11982,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeigen"
+            "state" : "needs_review",
+            "value" : "Anzeige"
           }
         },
         "en-GB" : {
@@ -26708,8 +26708,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereiten …"
+            "state" : "needs_review",
+            "value" : "Wird vorbereitet…"
           }
         },
         "en-GB" : {
@@ -28103,8 +28103,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzt"
+            "state" : "needs_review",
+            "value" : "Zuletzt verwendet"
           }
         },
         "en" : {
@@ -31093,8 +31093,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Strich"
+            "state" : "needs_review",
+            "value" : "Schrägstrich"
           }
         },
         "en-GB" : {
@@ -36175,8 +36175,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Als Favorit entfernen"
+            "state" : "needs_review",
+            "value" : "Aus Favoriten entfernen"
           }
         },
         "en" : {
@@ -37303,7 +37303,7 @@
         }
       }
     },
-    "Waves" : {
+    "appIcon.waves" : {
       "comment" : "The display name of the 'Waves' app icon.",
       "extractionState" : "manual",
       "localizations" : {

--- a/Blankie/Managers/Audio/AudioManager+SwiftData.swift
+++ b/Blankie/Managers/Audio/AudioManager+SwiftData.swift
@@ -122,6 +122,10 @@ extension AudioManager {
     await PresetManager.shared.initializePresetManager()
 
     reconcileLaunchPlaybackState()
+
+    // Publish the initial Siri/Shortcuts vocabulary and Spotlight index now that
+    // presets and sounds are fully loaded.
+    PresetManager.shared.refreshDiscoverableEntitiesIfNeeded()
   }
 
   /// Once every sound and preset is loaded, drop favorites whose target no
@@ -195,6 +199,10 @@ extension AudioManager {
           if notification.name == .customSoundDeleted {
             PresetManager.shared.cleanupDeletedCustomSounds()
           }
+
+          // A custom sound was added or removed — refresh Siri parameters and
+          // the Spotlight index so `PlaySoundIntent` matches the current sounds.
+          PresetManager.shared.refreshDiscoverableEntitiesIfNeeded()
         }
       }
   }

--- a/Blankie/Managers/Presets/PresetManager.swift
+++ b/Blankie/Managers/Presets/PresetManager.swift
@@ -5,6 +5,7 @@
 //  Created by Cody Bromley on 1/1/25.
 //
 
+import CoreSpotlight
 import Foundation
 import Observation
 import SwiftUI
@@ -13,6 +14,10 @@ import os
 @Observable
 class PresetManager {
   @ObservationIgnored private var isInitializing = true
+  /// Signature of the preset/sound names last published to App Shortcuts, so
+  /// the (frequently-called) refresh no-ops unless the Siri parameter vocabulary
+  /// would actually differ. Per-process only; reset each launch.
+  @ObservationIgnored private var lastShortcutParameterSignature: Int?
   static let shared = PresetManager()
 
   private(set) var presets: [Preset] = []
@@ -954,9 +959,56 @@ extension PresetManager {
 
     updateCurrentPresetBeforeSave()
     performActualSave()
+    refreshDiscoverableEntitiesIfNeeded()
 
     Logger.presets.debug("PresetManager: --- End Saving Presets ---")
   }
+
+  /// Refresh the system's discoverable view of presets and sounds — the
+  /// Siri/Shortcuts parameter vocabulary backing `PlayPresetIntent`/
+  /// `PlaySoundIntent`, and the Spotlight entity index — when the set of names
+  /// has actually changed. Safe to call often: the signature guard collapses
+  /// no-op calls. Skipped in the widget extension, which also compiles this file.
+  func refreshDiscoverableEntitiesIfNeeded() {
+    #if !WIDGET_EXTENSION
+      let signature =
+        presets.map { "\($0.id.uuidString):\($0.name)" }.hashValue
+        ^ AudioManager.shared.sounds.map { "\($0.fileName):\($0.localizedTitle)" }.hashValue
+      guard signature != lastShortcutParameterSignature else { return }
+      lastShortcutParameterSignature = signature
+      // App Shortcuts don't surface on macOS; Spotlight indexing works on both.
+      #if !os(macOS)
+        BlankieShortcuts.updateAppShortcutParameters()
+      #endif
+      donateEntitiesToSpotlight()
+    #endif
+  }
+
+  #if !WIDGET_EXTENSION
+    /// Donate presets and solo-able sounds to their named Spotlight indexes so
+    /// they surface in system search. Entity arrays are built on the main actor
+    /// here; the indexing itself runs off it. Failures are non-fatal.
+    private func donateEntitiesToSpotlight() {
+      let presetEntities = presets.map(PresetEntity.init)
+      let soundEntities =
+        AudioManager.shared.sounds
+        .filter { !$0.isPresetUseOnly }
+        .map(SoundEntity.init)
+      // Named indexes keyed off the app's own bundle ID (so contributor builds
+      // don't collide), not the default index Apple reserves for dev/testing.
+      let bundleID = Bundle.main.bundleIdentifier ?? "com.codybrom.blankie"
+      Task {
+        do {
+          try await CSSearchableIndex(name: "\(bundleID).presets")
+            .indexAppEntities(presetEntities)
+          try await CSSearchableIndex(name: "\(bundleID).sounds")
+            .indexAppEntities(soundEntities)
+        } catch {
+          Logger.presets.error("Spotlight: entity indexing failed: \(error, privacy: .public)")
+        }
+      }
+    }
+  #endif
 
   @MainActor
   private func updateCurrentPresetBeforeSave() {

--- a/Blankie/Managers/Presets/PresetManager.swift
+++ b/Blankie/Managers/Presets/PresetManager.swift
@@ -14,10 +14,12 @@ import os
 @Observable
 class PresetManager {
   @ObservationIgnored private var isInitializing = true
-  /// Signature of the preset/sound names last published to App Shortcuts, so
-  /// the (frequently-called) refresh no-ops unless the Siri parameter vocabulary
-  /// would actually differ. Per-process only; reset each launch.
-  @ObservationIgnored private var lastShortcutParameterSignature: Int?
+  /// Signature of the preset/sound names last published to Siri and Spotlight,
+  /// so the (frequently-called) refresh no-ops unless the discoverable set would
+  /// actually differ. A sorted, joined string (like AudioManager's Now Playing
+  /// selection guard) — deterministic and order-independent, unlike a hashValue.
+  /// Per-process only; reset each launch.
+  @ObservationIgnored private var lastDiscoverableEntitiesSignature: String?
   static let shared = PresetManager()
 
   private(set) var presets: [Preset] = []
@@ -971,11 +973,18 @@ extension PresetManager {
   /// no-op calls. Skipped in the widget extension, which also compiles this file.
   func refreshDiscoverableEntitiesIfNeeded() {
     #if !WIDGET_EXTENSION
-      let signature =
-        presets.map { "\($0.id.uuidString):\($0.name)" }.hashValue
-        ^ AudioManager.shared.sounds.map { "\($0.fileName):\($0.localizedTitle)" }.hashValue
-      guard signature != lastShortcutParameterSignature else { return }
-      lastShortcutParameterSignature = signature
+      // Deterministic, order-independent signature over exactly what's donated
+      // (presets + non-preset-only sounds, matching `donateEntitiesToSpotlight`
+      // and `SoundEntityQuery`), so reordering alone doesn't force a refresh.
+      let presetPart = presets.map { "\($0.id.uuidString):\($0.name)" }.sorted()
+      let soundPart =
+        AudioManager.shared.sounds
+        .filter { !$0.isPresetUseOnly }
+        .map { "\($0.fileName):\($0.localizedTitle)" }
+        .sorted()
+      let signature = (presetPart + ["~"] + soundPart).joined(separator: "|")
+      guard signature != lastDiscoverableEntitiesSignature else { return }
+      lastDiscoverableEntitiesSignature = signature
       // App Shortcuts don't surface on macOS; Spotlight indexing works on both.
       #if !os(macOS)
         BlankieShortcuts.updateAppShortcutParameters()

--- a/Blankie/UI/Components/SoloSoundIcon.swift
+++ b/Blankie/UI/Components/SoloSoundIcon.swift
@@ -100,10 +100,11 @@ struct SoloSoundIcon: View {
 /// surface, so this replaces the grid rather than living in a separate sheet.
 struct SoloSoundCard: View {
   let sound: Sound
+  var iconSize: CGFloat = 200
 
   var body: some View {
     VStack(spacing: 16) {
-      SoloSoundIcon(sound: sound)
+      SoloSoundIcon(sound: sound, iconSize: iconSize)
         // The card's text below carries the name and subtitle to VoiceOver, so
         // the icon is decorative here — hide it to avoid announcing the title
         // twice while keeping the subtitle reachable.

--- a/Blankie/UI/Views/AppIconPickerView.swift
+++ b/Blankie/UI/Views/AppIconPickerView.swift
@@ -106,7 +106,7 @@ import os
         ("BlankieDarkIcon", String(localized: "Dark")),
         ("BlankieSliderIcon", String(localized: "Slider")),
         ("BlankieAltIcon", String(localized: "Alternative")),
-        ("BlankieWavesIcon", String(localized: "Waves")),
+        ("BlankieWavesIcon", String(localized: "appIcon.waves", defaultValue: "Waves")),
         ("BlankieClassicIcon", String(localized: "Classic")),
         ("BlankiePatchworkIcon", String(localized: "Inspired by Blanket by Rafael Mardojai CM")),
       ]

--- a/Blankie/UI/Views/MenuBarContent.swift
+++ b/Blankie/UI/Views/MenuBarContent.swift
@@ -171,7 +171,7 @@
     private var mixerContent: some View {
       VStack(spacing: 0) {
         if let solo = audioManager.soloModeSound {
-          SoloSoundIcon(sound: solo, iconSize: 120)
+          SoloSoundCard(sound: solo, iconSize: 120)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 28)
         } else {

--- a/BlankieTests/AudioStateMachineTests.swift
+++ b/BlankieTests/AudioStateMachineTests.swift
@@ -125,4 +125,32 @@ import Testing
     #expect(a.isSelected, "prior selection is restored on exit")
     #expect(a.volume == 0.5)
   }
+
+  // MARK: - Leaving transient modes
+
+  /// `leaveTransientModes` clears solo — the exit the Siri (`PlayPresetIntent`/
+  /// `PlaySoundIntent`) and widget play intents run first, so what they apply
+  /// isn't masked by an active solo sound.
+  @Test func leaveTransientModesExitsSolo() {
+    let solo = TestSound(fileName: "test-solo")
+    audioManager.sounds = [solo]
+    audioManager.enterSoloMode(for: solo, startPlaying: false)
+    #expect(audioManager.soloModeSound != nil)
+
+    audioManager.leaveTransientModes()
+    #expect(audioManager.soloModeSound == nil)
+  }
+
+  /// `leaveTransientModes` clears Quick Mix, so a later Quick Mix action enters
+  /// fresh instead of toggling on top of a still-active mix.
+  @Test func leaveTransientModesExitsQuickMix() {
+    let a = TestSound(fileName: "test-a")
+    a.isSelected = true
+    audioManager.sounds = [a]
+    audioManager.enterQuickMix()
+    #expect(audioManager.isQuickMix)
+
+    audioManager.leaveTransientModes()
+    #expect(!audioManager.isQuickMix)
+  }
 }

--- a/BlankieTests/SoundMetadataModelTests.swift
+++ b/BlankieTests/SoundMetadataModelTests.swift
@@ -30,6 +30,35 @@ import Testing
     }
   }
 
+  /// Every built-in sound ships a non-empty subtitle caption (the character
+  /// line shown under the title in Now Playing and the sound pickers).
+  @Test func everyBuiltInSoundHasSubtitle() throws {
+    let url = try #require(Bundle.main.url(forResource: "sounds", withExtension: "json"))
+    let container = try JSONDecoder().decode(SoundsContainer.self, from: Data(contentsOf: url))
+    for sound in container.sounds {
+      #expect(
+        !(sound.subtitle ?? "").isEmpty,
+        "built-in sound '\(sound.fileName)' is missing a subtitle")
+    }
+  }
+
+  /// Each subtitle string is a key in the compiled string catalog. `Sound`'s
+  /// `localizedSubtitle` looks the subtitle up with `NSLocalizedString`, so a
+  /// subtitle edited in sounds.json without a matching catalog key would
+  /// silently fall back to English — this catches that drift.
+  @Test func everySubtitleHasCatalogEntry() throws {
+    let url = try #require(Bundle.main.url(forResource: "sounds", withExtension: "json"))
+    let container = try JSONDecoder().decode(SoundsContainer.self, from: Data(contentsOf: url))
+    let sentinel = "\u{1}__missing__"
+    for sound in container.sounds {
+      guard let subtitle = sound.subtitle, !subtitle.isEmpty else { continue }
+      let resolved = Bundle.main.localizedString(forKey: subtitle, value: sentinel, table: nil)
+      #expect(
+        resolved != sentinel,
+        "subtitle for '\(sound.fileName)' has no string-catalog key: \(subtitle)")
+    }
+  }
+
   @Test func soundMoodHasThreeCasesAndRoundTrips() throws {
     #expect(SoundMood.allCases.count == 3)
     for mood in SoundMood.allCases {

--- a/BlankieWidget/BlankieWidget.swift
+++ b/BlankieWidget/BlankieWidget.swift
@@ -110,10 +110,12 @@ struct NowPlayingSmallCard<PlayIntent: AppIntent>: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       HStack(alignment: .top) {
-        WidgetArtwork(thumbnailKey: thumbnailKey, fallbackIcon: fallbackIcon, accentColor: accentColor)
-          .frame(width: 56, height: 56)
-          .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-          .shadow(color: .black.opacity(0.3), radius: 6, y: 3)
+        WidgetArtwork(
+          thumbnailKey: thumbnailKey, fallbackIcon: fallbackIcon, accentColor: accentColor
+        )
+        .frame(width: 56, height: 56)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .shadow(color: .black.opacity(0.3), radius: 6, y: 3)
 
         Spacer()
 

--- a/BlankieWidget/BlankieWidgetBundle.swift
+++ b/BlankieWidget/BlankieWidgetBundle.swift
@@ -5,17 +5,17 @@
 //  Created by Cody Bromley on 7/1/26.
 //
 
-import WidgetKit
 import SwiftUI
+import WidgetKit
 
 @main
 struct BlankieWidgetBundle: WidgetBundle {
-    var body: some Widget {
-        NowPlayingWidget()
-        FavoritesWidget()
-        PinnedItemWidget()
-        QuickMixWidget()
-        PlaybackControl()
-        FavoriteControl()
-    }
+  var body: some Widget {
+    NowPlayingWidget()
+    FavoritesWidget()
+    PinnedItemWidget()
+    QuickMixWidget()
+    PlaybackControl()
+    FavoriteControl()
+  }
 }


### PR DESCRIPTION
Deferred follow-ups from the v2.1.0 PR reviews (#108–#111) and the earlier audit, batched onto one branch. Each commit is a single concern.

## Fixes
- **Widget build settings** — the `BlankieWidgetExtension` hardcoded its bundle ID to the official `com.codybrom.blankie.BlankieWidget` (breaking contributor builds' appex codesign/embedding) and set 26.5 deployment targets while the app ships 26.4/26.0/26.0 (silently withholding widgets below 26.5). Bundle ID now derives from the container app; deployment targets match the app.
- **Siri play intents** — `PlayPresetIntent`/`PlaySoundIntent` now `leaveTransientModes()` before acting, so a preset/sound isn't masked by an active solo sound and Quick Mix doesn't stay stuck (mirrors `WidgetPlayFavoriteIntent`).
- **German localization** — reverted 6 promotions that were stamped `translated` with worse values (`Anzeige`, `Zuletzt verwendet`, `Schrägstrich`, `Aus Favoriten entfernen`, `Aktuell`, `Wird vorbereitet…`), re-marked `needs_review` for a human pass.

## Features
- **Siri + Spotlight discovery** — presets and sounds conform to `IndexedEntity` and are donated to named Spotlight indexes (keyed off the bundle ID); the Siri/Shortcuts parameter vocabulary is refreshed alongside them. One signature-guarded pass runs at launch, after preset saves, and on custom-sound add/delete — so `updateAppShortcutParameters()` is finally called, and it doesn't re-donate on every state sync.
- **Menu-bar subtitle** — the soloed sound's subtitle now shows in the menu bar (parameterized `SoloSoundCard` icon size), matching the main window.
- **`Waves` app icon** re-keyed to `appIcon.waves`, decoupling it from the `sound.waves` title.

## Tests
- `leaveTransientModes()` clears solo and Quick Mix; every built-in sound has a non-empty subtitle whose string is present as a catalog key (guards the sounds.json ↔ catalog linkage).

Plus a `style(widgets)` commit applying swift-format to two widget files.

## Verification
`xcodebuild build` (iOS Simulator) and `build-for-testing` both succeed; tests compile (not run locally per the machine constraint — they'll run via the CI job on this PR).

## Still outstanding (own follow-up)
The intent + widget string **translation backfill** (~45 en-only intent strings, the widget extension's own catalog, and `AppShortcuts.xcstrings`, across ~12 locales) is intentionally not in this PR — it's a dedicated translation effort.