### PR TITLE
fix(quicklook): render preset previews with the app's fallback artwork

### DIFF
--- a/Blankie.xcodeproj/project.pbxproj
+++ b/Blankie.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		FADE000000000000005A0003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FADE000000000000005A0001 /* Assets.xcassets */; };
 		FADE000000000000005A0005 /* BrandAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FADE000000000000005A0004 /* BrandAssets.xcassets */; };
 		FADE000000000000005A0006 /* BrandAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FADE000000000000005A0004 /* BrandAssets.xcassets */; };
+		FADE000000000000005A0007 /* BrandAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FADE000000000000005A0004 /* BrandAssets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -207,6 +208,15 @@
 			);
 			target = F95914CF2FDF1D2300808460 /* BlankieAssetDownloader */;
 		};
+		FADE000000000000005B0001 /* Exceptions for "Blankie" folder in "BlankiePresetPreview" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Resources/sounds.json,
+				UI/Components/FallbackArtwork.swift,
+				"Utils/Extensions/Color+Extension.swift",
+			);
+			target = F94CB7982FEA47920077688E /* BlankiePresetPreview */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -237,6 +247,7 @@
 		F9BC93262D41457D00E450FC /* Blankie */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				FADE000000000000005B0001 /* Exceptions for "Blankie" folder in "BlankiePresetPreview" target */,
 				F91C40D12FF54FB100C58FC6 /* Exceptions for "Blankie" folder in "BlankieWidgetExtension" target */,
 			);
 			path = Blankie;
@@ -565,6 +576,7 @@
 			isa = PBXResourcesBuildPhase;
 			files = (
 				FADE000000000000005A0003 /* Assets.xcassets in Resources */,
+				FADE000000000000005A0007 /* BrandAssets.xcassets in Resources */,
 			);
 		};
 		F95914CE2FDF1D2300808460 /* Resources */ = {

--- a/BlankiePresetPreview/BuiltInSoundIcons.swift
+++ b/BlankiePresetPreview/BuiltInSoundIcons.swift
@@ -17,13 +17,20 @@ enum BuiltInSoundIcons {
   private static let map: [String: String] = {
     guard let url = Bundle.main.url(forResource: "sounds", withExtension: "json"),
       let data = try? Data(contentsOf: url),
-      let sounds = try? JSONDecoder().decode([Entry].self, from: data)
+      let catalog = try? JSONDecoder().decode(Catalog.self, from: data)
     else { return [:] }
     return Dictionary(
-      sounds.map { ($0.fileName, $0.systemIconName) }, uniquingKeysWith: { first, _ in first })
+      catalog.sounds.map { ($0.fileName, $0.systemIconName) },
+      uniquingKeysWith: { first, _ in first })
   }()
 
   static func icon(for fileName: String) -> String? { map[fileName] }
+
+  /// `sounds.json` is a top-level object wrapping the sound records in a
+  /// `sounds` array, not a bare array.
+  private struct Catalog: Decodable {
+    let sounds: [Entry]
+  }
 
   /// The only two fields the fallback needs from each `sounds.json` record.
   private struct Entry: Decodable {

--- a/BlankiePresetPreview/BuiltInSoundIcons.swift
+++ b/BlankiePresetPreview/BuiltInSoundIcons.swift
@@ -1,0 +1,33 @@
+//
+//  BuiltInSoundIcons.swift
+//  BlankiePresetPreview
+//
+//  Created by Cody Bromley on 7/8/26.
+//
+//  Maps a built-in sound's file name to its SF Symbol, read from the same
+//  bundled `sounds.json` the app ships. Bundling that single source of truth
+//  keeps the Quick Look fallback's sound icons in sync with the app instead of
+//  duplicating an icon table that would drift as sounds are added.
+//
+
+import Foundation
+
+enum BuiltInSoundIcons {
+  /// `fileName` → `systemIconName` for every built-in sound, parsed once.
+  private static let map: [String: String] = {
+    guard let url = Bundle.main.url(forResource: "sounds", withExtension: "json"),
+      let data = try? Data(contentsOf: url),
+      let sounds = try? JSONDecoder().decode([Entry].self, from: data)
+    else { return [:] }
+    return Dictionary(
+      sounds.map { ($0.fileName, $0.systemIconName) }, uniquingKeysWith: { first, _ in first })
+  }()
+
+  static func icon(for fileName: String) -> String? { map[fileName] }
+
+  /// The only two fields the fallback needs from each `sounds.json` record.
+  private struct Entry: Decodable {
+    let fileName: String
+    let systemIconName: String
+  }
+}

--- a/BlankiePresetPreview/PresetPreviewReader.swift
+++ b/BlankiePresetPreview/PresetPreviewReader.swift
@@ -95,24 +95,40 @@ enum PresetPreviewReader {
   private static func resolveIcons(
     for selected: [ArchivedSoundState], in archive: Archive
   ) -> [String] {
-    var overrides: [String: String] = [:]  // fileName -> customIconName
-    var customIcons: [String: String] = [:]  // fileName -> systemIconName
+    var overrides: [String: String] = [:]  // baseName -> customIconName
+    var customIcons: [String: String] = [:]  // baseName -> systemIconName
     if let data = entryData(in: archive, path: "sounds/metadata.json"),
       let manifest = try? JSONDecoder().decode(ArchivedSoundsManifest.self, from: data)
     {
       for sound in manifest.customSounds {
-        if let icon = sound.systemIconName { customIcons[sound.fileName] = icon }
+        if let icon = sound.systemIconName { customIcons[baseName(sound.fileName)] = icon }
       }
       for custom in manifest.builtInCustomizations {
-        if let icon = custom.customIconName { overrides[custom.fileName] = icon }
+        if let icon = custom.customIconName { overrides[baseName(custom.fileName)] = icon }
       }
     }
 
     return selected.compactMap { state in
-      overrides[state.fileName]
-        ?? customIcons[state.fileName]
-        ?? BuiltInSoundIcons.icon(for: state.fileName)
+      let key = baseName(state.fileName)
+      return overrides[key]
+        ?? customIcons[key]
+        ?? BuiltInSoundIcons.icon(for: key)
     }
+  }
+
+  /// A sound's file name reaches the fallback in two forms: a preset's
+  /// `soundStates` reference both built-ins and custom sounds by their base name
+  /// (no extension), while `sounds/metadata.json` stores custom sounds *with*
+  /// the extension (and legacy presets may carry a built-in's extension). Strip
+  /// a known audio extension so both sides key on the same base name.
+  private static let audioExtensions: Set<String> = [
+    "m4a", "mp3", "wav", "aif", "aiff", "flac", "ogg", "opus", "caf", "aac", "au",
+  ]
+
+  private static func baseName(_ fileName: String) -> String {
+    let ext = (fileName as NSString).pathExtension.lowercased()
+    guard !ext.isEmpty, audioExtensions.contains(ext) else { return fileName }
+    return (fileName as NSString).deletingPathExtension
   }
 
   /// Extract a single archive entry into memory without unpacking the whole zip,

--- a/BlankiePresetPreview/PresetPreviewReader.swift
+++ b/BlankiePresetPreview/PresetPreviewReader.swift
@@ -22,6 +22,16 @@ enum PresetPreviewReader {
     let creator: String?
     let soundCount: Int
     let artworkData: Data?
+    /// The preset's accent-color token (`"teal"`, `"indigo"`, …) or `nil` to
+    /// follow the app default. Resolved to a `Color` in the view.
+    let accentColorName: String?
+    /// SF Symbols for the preset's selected sounds, in order, so the no-artwork
+    /// fallback can render the same sound montage the app shows. Empty falls
+    /// back to the Blankie mark.
+    let iconNames: [String]
+    /// The exported default preset ("All Blankie Sounds"), which always shows
+    /// the brand mark rather than a montage.
+    let isDefault: Bool
   }
 
   /// Cap on a single decompressed *entry* — not the whole archive. The preview
@@ -64,13 +74,45 @@ enum PresetPreviewReader {
       }
     }
 
+    let selected = preset.soundStates.filter(\.isSelected)
     let creator = preset.creatorName?.trimmingCharacters(in: .whitespacesAndNewlines)
     return PresetInfo(
       name: preset.name,
       creator: (creator?.isEmpty == false) ? creator : nil,
-      soundCount: preset.soundStates.filter(\.isSelected).count,
-      artworkData: artworkData
+      soundCount: selected.count,
+      artworkData: artworkData,
+      accentColorName: preset.accentColorName,
+      iconNames: resolveIcons(for: selected, in: archive),
+      isDefault: preset.isDefault ?? false
     )
+  }
+
+  /// Resolve each selected sound to its SF Symbol, in preset order, so the
+  /// no-artwork fallback shows the preset's own sounds. Mirrors the app's icon
+  /// precedence: a per-preset icon override wins, then a custom sound's own
+  /// icon, then the built-in catalog. Sounds we can't map are dropped rather
+  /// than shown as a generic placeholder.
+  private static func resolveIcons(
+    for selected: [ArchivedSoundState], in archive: Archive
+  ) -> [String] {
+    var overrides: [String: String] = [:]  // fileName -> customIconName
+    var customIcons: [String: String] = [:]  // fileName -> systemIconName
+    if let data = entryData(in: archive, path: "sounds/metadata.json"),
+      let manifest = try? JSONDecoder().decode(ArchivedSoundsManifest.self, from: data)
+    {
+      for sound in manifest.customSounds {
+        if let icon = sound.systemIconName { customIcons[sound.fileName] = icon }
+      }
+      for custom in manifest.builtInCustomizations {
+        if let icon = custom.customIconName { overrides[custom.fileName] = icon }
+      }
+    }
+
+    return selected.compactMap { state in
+      overrides[state.fileName]
+        ?? customIcons[state.fileName]
+        ?? BuiltInSoundIcons.icon(for: state.fileName)
+    }
   }
 
   /// Extract a single archive entry into memory without unpacking the whole zip,
@@ -95,8 +137,28 @@ private struct ArchivedPreset: Decodable {
   let name: String
   let creatorName: String?
   let soundStates: [ArchivedSoundState]
+  let accentColorName: String?
+  let isDefault: Bool?
 }
 
 private struct ArchivedSoundState: Decodable {
+  let fileName: String
   let isSelected: Bool
+}
+
+/// A subset of the app's `SoundsManifest` (`sounds/metadata.json`), read only
+/// for the sounds' icons.
+private struct ArchivedSoundsManifest: Decodable {
+  let customSounds: [ArchivedCustomSound]
+  let builtInCustomizations: [ArchivedCustomization]
+
+  struct ArchivedCustomSound: Decodable {
+    let fileName: String
+    let systemIconName: String?
+  }
+
+  struct ArchivedCustomization: Decodable {
+    let fileName: String
+    let customIconName: String?
+  }
 }

--- a/BlankiePresetPreview/PresetPreviewView.swift
+++ b/BlankiePresetPreview/PresetPreviewView.swift
@@ -67,12 +67,15 @@ struct PresetPreviewView: View {
       if let data = preset.artworkData, let image = UIImage(data: data) {
         Image(uiImage: image).resizable().aspectRatio(contentMode: .fill)
       } else {
-        ZStack {
-          Color.white.opacity(0.08)
-          Image(systemName: "moon.stars.fill")
-            .font(.system(size: 40, weight: .medium))
-            .foregroundStyle(.white.opacity(0.85))
-        }
+        // The app's own no-artwork treatment: a montage of the preset's sound
+        // icons (or the Blankie mark) in the preset's accent, so Quick Look
+        // matches what Blankie shows for the same preset.
+        FallbackArtwork(
+          glyph: .playback(
+            isQuickMix: false, isDefaultPreset: preset.isDefault, icons: preset.iconNames),
+          accent: preset.accentColorName.flatMap(Color.init(fromString:)) ?? .accentColor,
+          size: 120,
+          cornerRadius: 22)
       }
     }
     .frame(width: 120, height: 120)
@@ -144,5 +147,7 @@ struct PresetPreviewView: View {
 
 #Preview {
   PresetPreviewView(
-    preset: .init(name: "Coquí Calling", creator: "Cody", soundCount: 1, artworkData: nil))
+    preset: .init(
+      name: "Coquí Calling", creator: "Cody", soundCount: 3, artworkData: nil,
+      accentColorName: "teal", iconNames: ["cloud.rain", "wind", "bird"], isDefault: false))
 }


### PR DESCRIPTION
## Summary

The Quick Look preset preview showed a bespoke moon-and-stars placeholder whenever a `.blankie` had no saved artwork — a one-off that never matched the app's own no-artwork treatment. This replaces it with the app's shared `FallbackArtwork`, so the Quick Look card looks identical to what Blankie renders for the same preset: a montage of the preset's own sound icons (or the Blankie mark) in the preset's accent color, on the dark accent-tinted card.

## What changed

- **`PresetPreviewReader`** now also reads the preset's `accentColorName`, its selected sounds' filenames, and resolves each sound's SF Symbol — honoring a per-preset icon override, then a custom sound's own icon (from the archive's `sounds/metadata.json`), then the built-in catalog.
- **`BuiltInSoundIcons`** (new) maps built-in `fileName → systemIconName` by reading the bundled `sounds.json`, keeping the Quick Look icons in sync with the app instead of a hand-maintained table.
- **`PresetPreviewView`** renders `FallbackArtwork(glyph: .playback(...), accent:)` in place of the moon.
- **Project** shares `FallbackArtwork.swift`, `Color+Extension.swift`, `Resources/sounds.json`, and `BrandAssets.xcassets` into the `BlankiePresetPreview` target (same synced-folder mechanism the widget already uses).

## Testing

- Builds clean: `Blankie (Universal)`, iOS Simulator, Debug.
- Not visually verified in this environment — Quick Look extensions can't host SwiftUI previews, so the pixel-level check is opening a real artwork-less `.blankie` in Files/Messages on device.

## Note

`FallbackArtwork.swift` is now also a member of the Quick Look appex (which can't host previews), so rendering that file's canvas preview may resolve to the extension; it previews fine hosted by the app or widget target.