### PR TITLE
fix(nowplaying): resolve animated-artwork launch crash and lock-screen next/previous

### DIFF
--- a/Blankie/Managers/Audio/NowPlayingManager+AnimatedArtwork.swift
+++ b/Blankie/Managers/Audio/NowPlayingManager+AnimatedArtwork.swift
@@ -94,19 +94,34 @@ import os
       let previewPath = preset.animatedArtwork?.previewPath ?? preset.staticArtworkPath
 
       let artworkID = loopKey ?? preset.id.uuidString
-      let animatedArtwork = MPMediaItemAnimatedArtwork(
+      nowPlayingInfo[artworkKey.rawValue] = Self.makeAnimatedArtwork(
         artworkID: artworkID,
-        previewImageRequestHandler: { _, completion in
-          completion(resources.previewImage)
-        },
-        videoAssetFileURLRequestHandler: { _, completion in
-          completion(resources.loopURL)
-        }
+        previewImage: resources.previewImage,
+        loopURL: resources.loopURL
       )
-
-      nowPlayingInfo[artworkKey.rawValue] = animatedArtwork
       currentAnimatedLoopPath = loopKey
       currentAnimatedPreviewPath = previewPath
+    }
+
+    /// Wraps the preview image and loop URL in `MPMediaItemAnimatedArtwork`.
+    /// Declared `nonisolated` so the request handler closures do NOT inherit
+    /// `NowPlayingManager`'s `@MainActor` isolation — MediaRemote invokes them
+    /// from its own `NowPlayingInfo` serial queue, and an isolated closure traps
+    /// the runtime's executor check there (mirrors `makeArtwork`).
+    nonisolated static func makeAnimatedArtwork(
+      artworkID: String,
+      previewImage: UIImage,
+      loopURL: URL
+    ) -> MPMediaItemAnimatedArtwork {
+      MPMediaItemAnimatedArtwork(
+        artworkID: artworkID,
+        previewImageRequestHandler: { _, completion in
+          completion(previewImage)
+        },
+        videoAssetFileURLRequestHandler: { _, completion in
+          completion(loopURL)
+        }
+      )
     }
 
     func removeAnimatedArtwork() {

--- a/Blankie/Managers/Presets/PresetManager.swift
+++ b/Blankie/Managers/Presets/PresetManager.swift
@@ -31,6 +31,12 @@ class PresetManager {
         creatorName: currentPreset?.creatorName,
         artworkId: currentPreset?.artworkId
       )
+      // The lock-screen / CarPlay next & previous cycle is favorites-only and
+      // depends on where the now-current preset sits in that list. Media-controls
+      // setup computes it once before presets have loaded, so recompute on every
+      // preset change (this also fires when the last-active preset is applied at
+      // launch, after favorites and presets are available).
+      AudioManager.shared.updateNextPreviousCommandState()
     }
   }
 


### PR DESCRIPTION
Two independent, pre-existing bugs surfaced while testing on device. Both affect every launch (not tied to any in-flight feature branch).

## 1. Launch crash: animated-artwork handlers trap off the main actor

`MPMediaItemAnimatedArtwork`'s `previewImageRequestHandler` / `videoAssetFileURLRequestHandler` were defined inline in the `@MainActor` method `publishAnimatedArtwork`, so they inherited main-actor isolation. MediaRemote invokes them on its own `PlaybackQueueNowPlayingInfo` serial queue, and a newer runtime traps `swift_task_isCurrentExecutor` when a closure claims the main actor while running off-main:

```
_dispatch_assert_queue_fail
swift_task_isCurrentExecutorWithFlagsImpl
closure #1 in NowPlayingManager.publishAnimatedArtwork
-[MPMediaItemAnimatedArtwork mrAnimatedArtwork]_block_invoke
```

Any launch that autoplays a preset with animated artwork crashed. Fixed by building the artwork in a `nonisolated static` helper, mirroring the existing `makeArtwork` helper that already documents this exact hazard.

## 2. Lock-screen / CarPlay next & previous stuck disabled after launch

`updateNextPreviousCommandState()` ran only at media-controls setup, on favorites edits, and on solo/Quick Mix transitions. Setup runs before presets finish loading, so `navigableItems` was empty and the commands were disabled — and nothing recomputed them once the last-active preset and favorites loaded. Now recomputed in `currentPreset.didSet`, so applying a preset (launch restore and every later switch) re-enables the favorites cycle when there is somewhere to go.

## Verification
- `** BUILD SUCCEEDED **` (iOS Simulator)
- swift-format lint clean
- Swept sibling MediaRemote/command callbacks: `MPMediaItemArtwork` already `nonisolated`; remote command handlers hop via `Task { @MainActor }` — no other instances of this class.