### PR TITLE
perf(nowplaying): resolve pack URLs off-main and trim verbose debug logs

### DIFF
--- a/Blankie/Managers/Audio/Sound.swift
+++ b/Blankie/Managers/Audio/Sound.swift
@@ -250,7 +250,6 @@ open class Sound: NSObject, Identifiable {
           }
 
           UserDefaults.shared.set(self.volume, forKey: "\(self.fileName)_volume")
-          Logger.sounds.debug("Sound: \(self.fileName) final volume saved as \(self.volume)")
         }
       }
 

--- a/Blankie/Managers/BackgroundResourceManager.swift
+++ b/Blankie/Managers/BackgroundResourceManager.swift
@@ -63,6 +63,12 @@ final class BackgroundResourceManager: ObservableObject {
     /// of racing several.
     private var inFlight: [String: Task<URL, Error>] = [:]
 
+    /// Resolved playable URLs per pack id. `AssetPackManager.url(for:)` warns
+    /// (and can hang) when called on the main thread, so it is resolved off the
+    /// main actor exactly once per pack and memoized here — the pack's location
+    /// is stable while it stays on disk. Evicted when a pack is removed.
+    private var urlCache: [String: URL] = [:]
+
     /// Current network reachability, so we can warn before a download instead of
     /// failing with an opaque server error. A `.satisfied` path doesn't guarantee
     /// the download succeeds, so this only short-circuits the clearly-offline
@@ -89,7 +95,7 @@ final class BackgroundResourceManager: ObservableObject {
   /// the 3:4 portrait master is `<id>/<id>.mov`, and the 1:1 square crop (pack id
   /// `<id>Square`, used for iPad's lock screen) is `<id>/<id>Square.mov`. So a
   /// "…Square" pack maps back to its base folder rather than a folder of its own.
-  private func relativeVideoPath(for id: String) -> String {
+  private nonisolated func relativeVideoPath(for id: String) -> String {
     if id.hasSuffix("Square") {
       let base = String(id.dropLast("Square".count))
       return "\(base)/\(id).mov"
@@ -123,7 +129,7 @@ final class BackgroundResourceManager: ObservableObject {
       // Fast path: already on disk → mount without entering `.downloading`.
       if AssetPackManager.shared.assetPackIsAvailableLocally(withID: id) {
         states[id] = .available
-        return try AssetPackManager.shared.url(for: FilePath(relativeVideoPath(for: id)))
+        return try await cachedURL(for: id)
       }
 
       // A download is required. If we're clearly offline, warn now rather than
@@ -163,8 +169,15 @@ final class BackgroundResourceManager: ObservableObject {
   /// synchronously and triggers a download separately when this returns nil.
   func availableURL(for id: String) -> URL? {
     #if os(iOS)
-      guard AssetPackManager.shared.assetPackIsAvailableLocally(withID: id) else { return nil }
-      return try? AssetPackManager.shared.url(for: FilePath(relativeVideoPath(for: id)))
+      guard AssetPackManager.shared.assetPackIsAvailableLocally(withID: id) else {
+        urlCache[id] = nil
+        return nil
+      }
+      // Read only the memoized URL — never resolve here. This runs on the main
+      // actor (Now Playing), and `AssetPackManager.url(for:)` warns/hangs on the
+      // main thread. On a miss, the Now Playing path calls `resourceURL(for:)`,
+      // which resolves off the main actor, caches, and republishes.
+      return urlCache[id]
     #else
       return nil
     #endif
@@ -190,6 +203,7 @@ final class BackgroundResourceManager: ObservableObject {
       do {
         try await AssetPackManager.shared.remove(assetPackWithID: id)
         states[id] = .notDownloaded
+        urlCache[id] = nil
         logger.info("Removed artwork asset pack \(id, privacy: .public)")
       } catch {
         logger.error(
@@ -212,6 +226,22 @@ final class BackgroundResourceManager: ObservableObject {
   }
 
   #if os(iOS)
+    // MARK: - URL resolution
+
+    /// Memoized playable URL for a locally-available pack, resolving
+    /// `AssetPackManager.url(for:)` off the main actor (it warns and can hang on
+    /// the main thread). The pack location is stable while on disk, so it is
+    /// resolved at most once per pack per session.
+    private func cachedURL(for id: String) async throws -> URL {
+      if let cached = urlCache[id] { return cached }
+      let path = relativeVideoPath(for: id)
+      let url = try await Task.detached {
+        try AssetPackManager.shared.url(for: FilePath(path))
+      }.value
+      urlCache[id] = url
+      return url
+    }
+
     // MARK: - Download
 
     private func download(id: String) async throws -> URL {
@@ -229,7 +259,7 @@ final class BackgroundResourceManager: ObservableObject {
           of: pack, requireLatestVersion: false)
         states[id] = .available
         logger.info("Downloaded artwork asset pack \(id, privacy: .public)")
-        return try AssetPackManager.shared.url(for: FilePath(relativeVideoPath(for: id)))
+        return try await cachedURL(for: id)
       } catch {
         // Log the raw error for diagnostics, but surface a friendly one to the
         // UI. If the network dropped mid-download, prefer the offline message.

--- a/Blankie/Managers/BackgroundResourceManager.swift
+++ b/Blankie/Managers/BackgroundResourceManager.swift
@@ -246,6 +246,11 @@ final class BackgroundResourceManager: ObservableObject {
 
     private func download(id: String) async throws -> URL {
       states[id] = .downloading(progress: 0)
+      // Drop any memoized URL before (re)downloading: if the system evicted the
+      // pack out from under us, a fresh install can land at a different URL, so
+      // the post-download `cachedURL(for:)` must resolve anew rather than return
+      // the stale pre-eviction value.
+      urlCache[id] = nil
 
       // Mirror live download progress into `states` for the gallery UI.
       let progressTask = Task { [weak self] in await self?.observeProgress(id: id) }

--- a/Blankie/Managers/Presets/PresetManager.swift
+++ b/Blankie/Managers/Presets/PresetManager.swift
@@ -1061,13 +1061,9 @@ extension PresetManager {
       updatePresetAtIndex(index, with: updatedPreset)
       setCurrentPreset(updatedPreset)
 
-      Logger.presets.debug("Saving current preset state for '\(updatedPreset.name)':")
-      Logger.presets.debug("  - Active sounds:")
-      updatedPreset.soundStates
-        .filter { $0.isSelected }
-        .forEach { state in
-          Logger.presets.debug("    * \(state.fileName) (Volume: \(state.volume))")
-        }
+      let activeCount = updatedPreset.soundStates.filter { $0.isSelected }.count
+      Logger.presets.debug(
+        "Saving current preset state for '\(updatedPreset.name)' (\(activeCount) active sounds)")
     }
   }
 

--- a/Blankie/Models/PresetStorage.swift
+++ b/Blankie/Models/PresetStorage.swift
@@ -92,19 +92,7 @@ struct PresetStorage {
 
     do {
       let presets = try JSONDecoder().decode([Preset].self, from: data)
-      let summary = presets.map { preset in
-        let sounds = preset.soundStates.filter { $0.isSelected }
-          .map { "      - \($0.fileName) (Volume: \($0.volume))" }
-        return
-          ([
-            "  - '\(preset.name)':",
-            "    * Order: \(preset.order ?? -1)",
-            "    * Artwork ID: \(preset.artworkId?.uuidString ?? "None")",
-            "    * Creator: \(preset.creatorName ?? "None")",
-            "    * Active sounds:",
-          ] + sounds).joined(separator: "\n")
-      }.joined(separator: "\n")
-      Logger.presets.debug("PresetStorage: Loaded \(presets.count) custom presets\n\(summary)")
+      Logger.presets.debug("PresetStorage: Loaded \(presets.count) custom presets")
       return presets
     } catch {
       // The library failed to decode as a whole. Back up the raw blob so it's


### PR DESCRIPTION
Two console-noise / perf cleanups found while device-testing (both app-wide, unrelated to any feature branch).

## 1. `perf`: resolve animated-artwork pack URLs off the main thread

`AssetPackManager.url(for:)` warns (`could cause UI hangs`) and can block when called on the main thread, but the Now Playing path resolved it synchronously on the main actor on **every** publish — flooding the log and risking hangs.

Memoize resolved URLs per pack (the location is stable while the pack is on disk) and resolve `url(for:)` off the main actor via a detached task. `availableURL` now only reads the cache: a miss returns nil, and the Now Playing path's existing coalesced retry calls `resourceURL`, which resolves off-main, caches, and republishes — so animated artwork self-heals without any main-thread `url(for:)` call. Cache is evicted when a pack is removed.

**Behavior note for reviewers:** at a cold launch a pack that isn't yet cached makes the first `availableURL` return nil, so the lock-screen animated artwork can appear one publish-cycle later (the still thumbnail is unaffected). Verified on device.

## 2. `chore`: trim verbose launch/save debug logs

All `.debug` (already silent in Release), but they dominated the debug console:
- `PresetStorage.loadCustomPresets` dumped a full per-preset, per-sound listing (~90 lines) → count.
- `Sound` logged "final volume saved as" per sound on each save (~24 lines/launch) → dropped.
- `PresetManager` listed every active sound when saving current preset state → count.

Kept per-sound playback logs and the on-apply preset summary.

## Verification
- `** BUILD SUCCEEDED **` (iOS Simulator), swift-format lint clean