### PR TITLE
refactor: adopt PlayableItem for favorites identity (plan 007, phases 1–3)

### DIFF
--- a/Blankie.xcodeproj/project.pbxproj
+++ b/Blankie.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 				Models/CustomSoundData.swift,
 				Models/Language.swift,
 				Models/License.swift,
+				Models/PlayableItem.swift,
 				Models/PlaybackProfile.swift,
 				Models/Preset.swift,
 				Models/PresetArchive.swift,

--- a/Blankie.xcodeproj/project.pbxproj
+++ b/Blankie.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 				"Managers/Audio/AudioManager+Analysis.swift",
 				"Managers/Audio/AudioManager+MediaControls.swift",
 				"Managers/Audio/AudioManager+Notifications.swift",
+				"Managers/Audio/AudioManager+PlayableItem.swift",
 				"Managers/Audio/AudioManager+PlaybackControl.swift",
 				"Managers/Audio/AudioManager+QuickMix.swift",
 				"Managers/Audio/AudioManager+SoloMode.swift",

--- a/Blankie/CarPlay/Templates/HomeListTemplate.swift
+++ b/Blankie/CarPlay/Templates/HomeListTemplate.swift
@@ -111,18 +111,21 @@ import os
     private static func favoritesSection() -> CPListSection? {
       let presets = PresetManager.shared.presets
       let items: [CPListItem] = GlobalSettings.shared.starredItems.compactMap { token in
-        if let sound = AudioManager.shared.sound(forSoloToken: token) {
+        switch PlayableItem(token: token) {
+        case .solo(let fileName):
+          guard let sound = AudioManager.shared.sound(fileName: fileName) else { return nil }
           return PresetListTemplate.createSoloItem(sound)
-        }
-        switch token {
-        case GlobalSettings.allSoundsToken:
+        case .allSounds:
           guard let defaultPreset = presets.first(where: { $0.isDefault }) else { return nil }
           return PresetListTemplate.createAllSoundsItem(defaultPreset)
-        case GlobalSettings.quickMixToken:
+        case .quickMix:
+          // Quick Mix has its own tab, so its token is skipped here.
           return nil
-        default:
-          guard let preset = presets.first(where: { $0.id.uuidString == token }) else { return nil }
+        case .preset(let id):
+          guard let preset = presets.first(where: { $0.id == id }) else { return nil }
           return PresetListTemplate.createPresetListItem(preset)
+        case .none:
+          return nil
         }
       }
 

--- a/Blankie/Intents/WidgetPlayFavoriteIntent.swift
+++ b/Blankie/Intents/WidgetPlayFavoriteIntent.swift
@@ -57,33 +57,31 @@ struct WidgetPlayFavoriteIntent: AppIntent, AudioPlaybackIntent {
     // on top of the preset instead of entering fresh.
     audio.leaveTransientModes()
 
-    if favoriteToken == GlobalSettings.allSoundsToken {
+    switch PlayableItem(token: favoriteToken) {
+    case .allSounds:
       if let defaultPreset = PresetManager.shared.presets.first(where: { $0.isDefault }) {
         try PresetManager.shared.applyPreset(defaultPreset)
         audio.setGlobalPlaybackState(true)
       }
       return .result()
-    }
-
-    if favoriteToken == GlobalSettings.quickMixToken {
+    case .quickMix:
       audio.enterQuickMix()
       return .result()
-    }
-
-    if let fileName = GlobalSettings.soloFileName(fromToken: favoriteToken),
-      let soloSound = audio.sound(fileName: fileName)
-    {
+    case .solo(let fileName):
+      guard let soloSound = audio.sound(fileName: fileName) else {
+        throw BlankieIntentError.presetNotFound
+      }
       audio.enterSoloMode(for: soloSound)
       return .result()
-    }
-
-    guard let presetID = UUID(uuidString: favoriteToken),
-      let preset = PresetManager.shared.presets.first(where: { $0.id == presetID })
-    else {
+    case .preset(let id):
+      guard let preset = PresetManager.shared.presets.first(where: { $0.id == id }) else {
+        throw BlankieIntentError.presetNotFound
+      }
+      try PresetManager.shared.applyPreset(preset)
+      audio.setGlobalPlaybackState(true)
+      return .result()
+    case nil:
       throw BlankieIntentError.presetNotFound
     }
-    try PresetManager.shared.applyPreset(preset)
-    audio.setGlobalPlaybackState(true)
-    return .result()
   }
 }

--- a/Blankie/Managers/Audio/AudioManager+MediaControls.swift
+++ b/Blankie/Managers/Audio/AudioManager+MediaControls.swift
@@ -123,16 +123,18 @@ extension AudioManager {
   private var navigableItems: [NavigableItem] {
     let presets = PresetManager.shared.presets
     return GlobalSettings.shared.starredItems.compactMap { token in
-      if GlobalSettings.soloFileName(fromToken: token) != nil {
-        return sound(forSoloToken: token).map { NavigableItem.solo($0) }
-      }
-      switch token {
-      case GlobalSettings.allSoundsToken:
+      switch PlayableItem(token: token) {
+      case .solo(let fileName):
+        return sound(fileName: fileName).map { NavigableItem.solo($0) }
+      case .allSounds:
         return presets.first { $0.isDefault }.map { NavigableItem.preset($0) }
-      case GlobalSettings.quickMixToken:
+      case .quickMix:
+        // Quick Mix isn't part of the favorites navigation cycle.
         return nil
-      default:
-        return presets.first { $0.id.uuidString == token }.map { NavigableItem.preset($0) }
+      case .preset(let id):
+        return presets.first { $0.id == id }.map { NavigableItem.preset($0) }
+      case nil:
+        return nil
       }
     }
   }

--- a/Blankie/Managers/Audio/AudioManager+PlayableItem.swift
+++ b/Blankie/Managers/Audio/AudioManager+PlayableItem.swift
@@ -1,0 +1,69 @@
+//
+//  AudioManager+PlayableItem.swift
+//  Blankie
+//
+//  Created by Cody Bromley on 7/8/26.
+//
+//  The single resolution service for a PlayableItem's display fields — the
+//  name / icon / subtitle / accent / thumbnail every favorites surface (widget,
+//  CarPlay) used to re-derive by hand from a raw token. Domain-object surfaces
+//  (the in-app Library, media-control navigation) parse with `PlayableItem`
+//  directly and resolve to the Preset/Sound they need, so they don't route
+//  through here.
+//
+
+import Foundation
+
+/// The per-surface display fields for a `PlayableItem`, resolved once.
+struct PlayableItemDisplay {
+  var displayName: String
+  var systemIconName: String
+  var subtitle: String?
+  var accentColorName: String?
+  var thumbnailKey: String?
+}
+
+extension AudioManager {
+  /// Resolves a `PlayableItem` to its display fields, or nil when it points at a
+  /// sound/preset that no longer exists (a dead token). Non-preset items have no
+  /// accent of their own, so they use the app's `customAccentColor` — the same
+  /// fallback the live playback accent resolves to (see `widgetFavorite`).
+  @MainActor
+  func display(for item: PlayableItem) -> PlayableItemDisplay? {
+    let appAccent = GlobalSettings.shared.customAccentColor?.toString
+    switch item {
+    case .allSounds:
+      return PlayableItemDisplay(
+        displayName: String(localized: "All Blankie Sounds"),
+        systemIconName: "square.grid.2x2",
+        subtitle: nil,
+        accentColorName: appAccent,
+        thumbnailKey: nil)
+    case .quickMix:
+      return PlayableItemDisplay(
+        displayName: String(localized: "Quick Mix"),
+        systemIconName: "shuffle",
+        subtitle: nil,
+        accentColorName: appAccent,
+        thumbnailKey: nil)
+    case .solo(let fileName):
+      guard let soloSound = sound(fileName: fileName) else { return nil }
+      return PlayableItemDisplay(
+        displayName: soloSound.localizedTitle,
+        systemIconName: soloSound.systemIconName,
+        subtitle: soloSound.isCustom ? soloSound.creditedAuthor : nil,
+        accentColorName: appAccent,
+        thumbnailKey: nil)
+    case .preset(let id):
+      guard let preset = PresetManager.shared.presets.first(where: { $0.id == id }) else {
+        return nil
+      }
+      return PlayableItemDisplay(
+        displayName: preset.displayName,
+        systemIconName: "square.stack.3d.up.fill",
+        subtitle: presetSubtitle(for: preset),
+        accentColorName: preset.accentColorName,
+        thumbnailKey: "preset_thumb_\(preset.id.uuidString)")
+    }
+  }
+}

--- a/Blankie/Managers/Audio/AudioManager+PlayableItem.swift
+++ b/Blankie/Managers/Audio/AudioManager+PlayableItem.swift
@@ -24,6 +24,24 @@ struct PlayableItemDisplay {
 }
 
 extension AudioManager {
+  /// What is currently driving the mixer, as one identity: solo outranks Quick
+  /// Mix, which outranks the current preset (the default preset reads as
+  /// `.allSounds`). Nil when nothing is active. This is the single precedence
+  /// `currentFavoriteToken` and `PresetManager.themingPreset` both derive from.
+  @MainActor
+  var activeItem: PlayableItem? {
+    if let soloSound = soloModeSound {
+      return .solo(fileName: soloSound.fileName)
+    }
+    if isQuickMix {
+      return .quickMix
+    }
+    if let preset = PresetManager.shared.currentPreset {
+      return preset.isDefault ? .allSounds : .preset(preset.id)
+    }
+    return nil
+  }
+
   /// Resolves a `PlayableItem` to its display fields, or nil when it points at a
   /// sound/preset that no longer exists (a dead token). Non-preset items have no
   /// accent of their own, so they use the app's `customAccentColor` — the same

--- a/Blankie/Managers/Audio/AudioManager+Widgets.swift
+++ b/Blankie/Managers/Audio/AudioManager+Widgets.swift
@@ -143,21 +143,13 @@ extension AudioManager {
     return NowPlayingManager.soundNameSummary(titles)
   }
 
-  /// The `starredItems` token matching what's currently active, if any —
-  /// resolved the same way `PresetManager.themingPreset` picks what's "in
-  /// charge" of the mixer right now (solo, then Quick Mix, then preset).
+  /// The `starredItems` token matching what's currently active, if any — the
+  /// persisted form of `activeItem`, which also drives `themingPreset` so the
+  /// two agree on what's "in charge" of the mixer (solo, then Quick Mix, then
+  /// preset).
   @MainActor
   var currentFavoriteToken: String? {
-    if let soloSound = soloModeSound {
-      return GlobalSettings.soloToken(forFileName: soloSound.fileName)
-    }
-    if isQuickMix {
-      return GlobalSettings.quickMixToken
-    }
-    if let preset = PresetManager.shared.currentPreset {
-      return preset.isDefault ? GlobalSettings.allSoundsToken : preset.id.uuidString
-    }
-    return nil
+    activeItem?.token
   }
 
   /// Resolves one `starredItems` token to widget-display info, mirroring the

--- a/Blankie/Managers/Audio/AudioManager+Widgets.swift
+++ b/Blankie/Managers/Audio/AudioManager+Widgets.swift
@@ -170,47 +170,16 @@ extension AudioManager {
   /// fallback instead and read as a different, wrong color from what
   /// `NowPlayingWidget` shows for that same sound while it's playing.
   func widgetFavorite(forToken token: String) -> WidgetFavorite? {
-    if token == GlobalSettings.allSoundsToken {
-      return WidgetFavorite(
-        token: token,
-        displayName: String(localized: "All Blankie Sounds"),
-        systemIconName: "square.grid.2x2",
-        thumbnailKey: nil,
-        accentColorName: GlobalSettings.shared.customAccentColor?.toString,
-        subtitle: nil
-      )
+    guard let item = PlayableItem(token: token), let display = display(for: item) else {
+      return nil
     }
-    if token == GlobalSettings.quickMixToken {
-      return WidgetFavorite(
-        token: token,
-        displayName: String(localized: "Quick Mix"),
-        systemIconName: "shuffle",
-        thumbnailKey: nil,
-        accentColorName: GlobalSettings.shared.customAccentColor?.toString,
-        subtitle: nil
-      )
-    }
-    if let fileName = GlobalSettings.soloFileName(fromToken: token) {
-      guard let soloSound = sound(fileName: fileName) else { return nil }
-      return WidgetFavorite(
-        token: token,
-        displayName: soloSound.localizedTitle,
-        systemIconName: soloSound.systemIconName,
-        thumbnailKey: nil,
-        accentColorName: GlobalSettings.shared.customAccentColor?.toString,
-        subtitle: soloSound.isCustom ? soloSound.creditedAuthor : nil
-      )
-    }
-    guard let presetID = UUID(uuidString: token),
-      let preset = PresetManager.shared.presets.first(where: { $0.id == presetID })
-    else { return nil }
     return WidgetFavorite(
       token: token,
-      displayName: preset.displayName,
-      systemIconName: "square.stack.3d.up.fill",
-      thumbnailKey: "preset_thumb_\(preset.id.uuidString)",
-      accentColorName: preset.accentColorName,
-      subtitle: presetSubtitle(for: preset)
+      displayName: display.displayName,
+      systemIconName: display.systemIconName,
+      thumbnailKey: display.thumbnailKey,
+      accentColorName: display.accentColorName,
+      subtitle: display.subtitle
     )
   }
 }

--- a/Blankie/Managers/Presets/PresetManager.swift
+++ b/Blankie/Managers/Presets/PresetManager.swift
@@ -55,9 +55,15 @@ class PresetManager {
   /// re-evaluates when solo / Quick Mix state changes.
   @MainActor
   var themingPreset: Preset? {
-    let audio = AudioManager.shared
-    if audio.soloModeSound != nil || audio.isQuickMix { return nil }
-    return currentPreset
+    // Derived from AudioManager.activeItem so this agrees with
+    // currentFavoriteToken: only a preset (or the default) themes the UI; solo
+    // and Quick Mix do not.
+    switch AudioManager.shared.activeItem {
+    case .preset, .allSounds:
+      return currentPreset
+    case .solo, .quickMix, .none:
+      return nil
+    }
   }
 
   /// Watches AudioManager's (now `@Observable`) sounds array for add/remove so a

--- a/Blankie/Managers/Settings/GlobalSettings+Setters.swift
+++ b/Blankie/Managers/Settings/GlobalSettings+Setters.swift
@@ -161,12 +161,16 @@ extension GlobalSettings {
   @MainActor
   func pruneStarredItems(validPresetIDs: Set<String>, validSoundFileNames: Set<String>? = nil) {
     let pruned = starredItems.filter { token in
-      if let fileName = GlobalSettings.soloFileName(fromToken: token) {
+      switch PlayableItem(token: token) {
+      case .allSounds, .quickMix:
+        return true
+      case .solo(let fileName):
         return validSoundFileNames?.contains(fileName) ?? true
+      case .preset(let id):
+        return validPresetIDs.contains(id.uuidString)
+      case nil:
+        return false
       }
-      return token == GlobalSettings.allSoundsToken
-        || token == GlobalSettings.quickMixToken
-        || validPresetIDs.contains(token)
     }
     if pruned != starredItems {
       setStarredItems(pruned)

--- a/Blankie/Managers/Settings/GlobalSettings.swift
+++ b/Blankie/Managers/Settings/GlobalSettings.swift
@@ -67,21 +67,23 @@ class GlobalSettings {
   static let shared = GlobalSettings()
 
   /// Tokens for the non-preset starrable items. Presets use their UUID string.
-  static let allSoundsToken = "allSounds"
-  static let quickMixToken = "quickMix"
+  /// These forward to `PlayableItem`, the single codec for the token grammar.
+  static let allSoundsToken = PlayableItem.allSounds.token
+  static let quickMixToken = PlayableItem.quickMix.token
 
   /// Prefix for solo-sound tokens. A soloed sound is starred as
   /// `"solo:<fileName>"`, using the sound's stable `fileName` as its identity.
-  static let soloTokenPrefix = "solo:"
+  static let soloTokenPrefix = PlayableItem.soloTokenPrefix
 
   /// The starred token for soloing the given sound file.
   static func soloToken(forFileName fileName: String) -> String {
-    soloTokenPrefix + fileName
+    PlayableItem.solo(fileName: fileName).token
   }
 
   /// The sound file name encoded in a solo token, or nil if it isn't one.
   static func soloFileName(fromToken token: String) -> String? {
-    token.hasPrefix(soloTokenPrefix) ? String(token.dropFirst(soloTokenPrefix.count)) : nil
+    if case .solo(let fileName) = PlayableItem(token: token) { return fileName }
+    return nil
   }
 
   var volume: Double

--- a/Blankie/Models/PlayableItem.swift
+++ b/Blankie/Models/PlayableItem.swift
@@ -1,0 +1,69 @@
+//
+//  PlayableItem.swift
+//  Blankie
+//
+//  Created by Cody Bromley on 7/8/26.
+//
+//  A single identity for "what a favorite / lock-screen / CarPlay / Siri entry
+//  points at": the default preset, a saved preset, Quick Mix, or a soloed sound.
+//  This is the one place the persisted `starredItems` token grammar is encoded
+//  and decoded — every surface that used to re-parse the four token shapes by
+//  hand can route through here instead. The `token` output is byte-identical to
+//  the strings already stored in App Group storage, so it is user data and must
+//  not change (pinned by WidgetTokenGrammarTests / PlayableItemTests).
+//
+
+import Foundation
+
+/// The four mutually exclusive things a favorite token can refer to.
+nonisolated enum PlayableItem: Equatable, Hashable {
+  /// The default preset ("All Blankie Sounds").
+  case allSounds
+  /// A saved preset, by id.
+  case preset(UUID)
+  /// The transient Quick Mix.
+  case quickMix
+  /// A soloed sound, identified by its stable `fileName`.
+  case solo(fileName: String)
+
+  // Canonical token strings. These are the persisted grammar — do not change.
+  private static let allSoundsToken = "allSounds"
+  private static let quickMixToken = "quickMix"
+  /// A soloed sound is stored as `"solo:<fileName>"`.
+  static let soloTokenPrefix = "solo:"
+
+  /// Decodes a persisted `starredItems` token, or nil if it isn't a valid one.
+  /// The special tokens and the solo prefix are checked before falling back to a
+  /// preset UUID, so the four shapes stay mutually exclusive.
+  init?(token: String) {
+    switch token {
+    case Self.allSoundsToken:
+      self = .allSounds
+    case Self.quickMixToken:
+      self = .quickMix
+    default:
+      if token.hasPrefix(Self.soloTokenPrefix) {
+        self = .solo(fileName: String(token.dropFirst(Self.soloTokenPrefix.count)))
+      } else if let id = UUID(uuidString: token) {
+        self = .preset(id)
+      } else {
+        return nil
+      }
+    }
+  }
+
+  /// The persisted token for this item — identical to the strings already in
+  /// App Group storage.
+  var token: String {
+    switch self {
+    case .allSounds:
+      return Self.allSoundsToken
+    case .quickMix:
+      return Self.quickMixToken
+    case .solo(let fileName):
+      return Self.soloTokenPrefix + fileName
+    case .preset(let id):
+      return id.uuidString
+    }
+  }
+}

--- a/Blankie/UI/Views/LibraryView.swift
+++ b/Blankie/UI/Views/LibraryView.swift
@@ -699,48 +699,51 @@ struct LibraryView: View {
 
   @ViewBuilder
   private func tokenRow(_ token: String) -> some View {
-    if let sound = audioManager.sound(forSoloToken: token) {
-      soloRow(sound)
-    } else {
-      switch token {
-      case GlobalSettings.allSoundsToken:
-        if let defaultPreset = presetManager.presets.first(where: { $0.isDefault }) {
-          PresetPickerRow(
-            preset: defaultPreset, isEditMode: isEditMode, dismissOnSelect: dismissOnSelect,
-            presentation: presentation, onSelection: onSelect)
-        }
-      default:
-        if let preset = presetManager.presets.first(where: { $0.id.uuidString == token }) {
-          let row = PresetPickerRow(
-            preset: preset, isEditMode: isEditMode, dismissOnSelect: dismissOnSelect,
-            presentation: presentation, onSelection: onSelect)
-          // Custom presets only — never the default or solo rows. macOS uses a
-          // context menu (replacing the old per-row pencil and trash); iOS/iPadOS
-          // offers the same edit/delete choice via a trailing swipe.
-          #if os(macOS)
-            row.contextMenu {
-              Button("Edit Preset…") { selectedPresetForEdit = preset }
-              Button("Delete Preset…", role: .destructive) { presetToDelete = preset }
-            }
-          #else
-            row.swipeActions(edge: .trailing, allowsFullSwipe: false) {
-              Button(role: .destructive) {
-                presetToDelete = preset
-              } label: {
-                Label("Delete", systemImage: "trash")
-              }
-              // Clear the inherited app accent so the destructive role's own
-              // danger color shows; Edit keeps the default (app accent) tint.
-              .tint(nil)
-              Button {
-                selectedPresetForEdit = preset
-              } label: {
-                Label("Edit", systemImage: "slider.vertical.3")
-              }
-            }
-          #endif
-        }
+    switch PlayableItem(token: token) {
+    case .solo(let fileName):
+      if let sound = audioManager.sound(fileName: fileName) {
+        soloRow(sound)
       }
+    case .allSounds:
+      if let defaultPreset = presetManager.presets.first(where: { $0.isDefault }) {
+        PresetPickerRow(
+          preset: defaultPreset, isEditMode: isEditMode, dismissOnSelect: dismissOnSelect,
+          presentation: presentation, onSelection: onSelect)
+      }
+    case .preset(let id):
+      if let preset = presetManager.presets.first(where: { $0.id == id }) {
+        let row = PresetPickerRow(
+          preset: preset, isEditMode: isEditMode, dismissOnSelect: dismissOnSelect,
+          presentation: presentation, onSelection: onSelect)
+        // Custom presets only — never the default or solo rows. macOS uses a
+        // context menu (replacing the old per-row pencil and trash); iOS/iPadOS
+        // offers the same edit/delete choice via a trailing swipe.
+        #if os(macOS)
+          row.contextMenu {
+            Button("Edit Preset…") { selectedPresetForEdit = preset }
+            Button("Delete Preset…", role: .destructive) { presetToDelete = preset }
+          }
+        #else
+          row.swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+              presetToDelete = preset
+            } label: {
+              Label("Delete", systemImage: "trash")
+            }
+            // Clear the inherited app accent so the destructive role's own
+            // danger color shows; Edit keeps the default (app accent) tint.
+            .tint(nil)
+            Button {
+              selectedPresetForEdit = preset
+            } label: {
+              Label("Edit", systemImage: "slider.vertical.3")
+            }
+          }
+        #endif
+      }
+    case .quickMix, .none:
+      // Quick Mix and dead tokens have no Library row (unchanged).
+      EmptyView()
     }
   }
 

--- a/BlankieTests/PlayableItemTests.swift
+++ b/BlankieTests/PlayableItemTests.swift
@@ -1,0 +1,85 @@
+//
+//  PlayableItemTests.swift
+//  BlankieTests
+//
+//  Created by Cody Bromley on 7/8/26.
+//
+//  PlayableItem is the single codec for the persisted `starredItems` token
+//  grammar (allSounds | quickMix | solo:<fileName> | preset-UUID). These pin the
+//  round-trip and byte-compatibility with the strings already in App Group
+//  storage; a change here is a change to user data. GlobalSettings' token
+//  helpers forward to this, so WidgetTokenGrammarTests covers them too.
+//
+
+import Foundation
+import Testing
+
+@testable import Blankie
+
+@Suite struct PlayableItemTests {
+
+  // MARK: - Encode
+
+  @Test func encodesEachShapeToItsPersistedToken() {
+    #expect(PlayableItem.allSounds.token == "allSounds")
+    #expect(PlayableItem.quickMix.token == "quickMix")
+    #expect(PlayableItem.solo(fileName: "rain").token == "solo:rain")
+    let id = UUID()
+    #expect(PlayableItem.preset(id).token == id.uuidString)
+  }
+
+  // MARK: - Decode
+
+  @Test func decodesEachShape() {
+    #expect(PlayableItem(token: "allSounds") == .allSounds)
+    #expect(PlayableItem(token: "quickMix") == .quickMix)
+    #expect(PlayableItem(token: "solo:rain") == .solo(fileName: "rain"))
+    let id = UUID()
+    #expect(PlayableItem(token: id.uuidString) == .preset(id))
+  }
+
+  @Test func rejectsInvalidTokens() {
+    #expect(PlayableItem(token: "") == nil)
+    #expect(PlayableItem(token: "not-a-uuid") == nil)
+    #expect(PlayableItem(token: "AllSounds") == nil)  // case-sensitive
+  }
+
+  // MARK: - Round-trip
+
+  @Test func roundTripsThroughToken() {
+    let items: [PlayableItem] = [
+      .allSounds, .quickMix, .solo(fileName: "distant-thunder"), .preset(UUID()),
+    ]
+    for item in items {
+      #expect(PlayableItem(token: item.token) == item)
+    }
+  }
+
+  /// A file name containing the delimiter survives: only the first `solo:` is
+  /// stripped, so the remainder is returned intact.
+  @Test func soloPreservesColonInFileName() {
+    let item = PlayableItem.solo(fileName: "a:b")
+    #expect(item.token == "solo:a:b")
+    #expect(PlayableItem(token: "solo:a:b") == item)
+  }
+
+  // MARK: - Mutual exclusivity
+
+  /// The special/solo tokens never parse as a preset UUID, and a UUID never
+  /// parses as one of the others — the four shapes stay disjoint.
+  @Test func shapesAreMutuallyExclusive() {
+    #expect(PlayableItem(token: "allSounds") != .preset(UUID()))
+    if case .preset = PlayableItem(token: "solo:rain") { Issue.record("solo parsed as preset") }
+    if case .solo = PlayableItem(token: UUID().uuidString) { Issue.record("uuid parsed as solo") }
+    if case .preset = PlayableItem(token: "quickMix") { Issue.record("quickMix parsed as preset") }
+  }
+
+  // MARK: - GlobalSettings forwarding stays byte-compatible
+
+  @Test func matchesGlobalSettingsTokens() {
+    #expect(PlayableItem.allSounds.token == GlobalSettings.allSoundsToken)
+    #expect(PlayableItem.quickMix.token == GlobalSettings.quickMixToken)
+    #expect(
+      PlayableItem.solo(fileName: "rain").token == GlobalSettings.soloToken(forFileName: "rain"))
+  }
+}


### PR DESCRIPTION
Implements plan 007 (phases 1–3): "what a favorite / lock-screen / CarPlay / Siri / widget entry points at" becomes one type instead of a token grammar re-parsed by hand at every surface.

## Phase 1 — the codec

`PlayableItem` (enum: `allSounds | preset(UUID) | quickMix | solo(fileName)`) with `init?(token:)` / `token`, byte-compatible with the persisted `starredItems` strings in App Group storage. `GlobalSettings`' token constants and helpers now forward to it — one source of truth. Added `PlayableItemTests`; the existing `WidgetTokenGrammarTests` (which pins the grammar through the forwarding helpers) is unchanged.

## Phase 2 — the resolvers

Six hand-rolled four-way token dispatches become exhaustive `switch PlayableItem(token:)`, so a token-shape change is compiler-enforced everywhere:

| Site | Change |
| --- | --- |
| `widgetFavorite(forToken:)` | parses via PlayableItem + delegates display fields to a new shared `AudioManager.display(for:)` (`PlayableItemDisplay`) |
| media-controls `navigableItems` | lock-screen / CarPlay next & previous |
| `LibraryView.tokenRow` | in-app favorites list |
| CarPlay `HomeListTemplate` favorites | |
| `GlobalSettings.pruneStarredItems` | token validity |
| `WidgetPlayFavoriteIntent` | action dispatch |

## Phase 3 — one active item

`AudioManager.activeItem: PlayableItem?` is the single precedence for what's driving the mixer (solo > Quick Mix > current preset; default reads as `.allSounds`). `currentFavoriteToken` is now `activeItem?.token`, and `PresetManager.themingPreset` derives from `activeItem` too, so the persisted-token view and the theming view can't disagree about what's "in charge."

## Behavior & verification
- Behavior-preserving throughout. The widget path stays pinned by `WidgetTokenGrammarTests` / `WidgetFavoriteResolutionTests`, which now also cover `display(for:)` and `activeItem` (via `currentFavoriteToken`). Library / CarPlay / media-controls still resolve to their `Preset`/`Sound` domain objects; only the parsing is unified.
- Persisted token format unchanged (user data) — pinned by the tests.
- app + widget + test targets compile (`TEST BUILD SUCCEEDED`); swift-format clean. Run the suite in Xcode to confirm green (local `xcodebuild test` is disabled here).

## Phase 4 — deliberately not done
Unifying the solo and Quick-Mix state machines into a shared `TemporaryMixSession` was evaluated against the actual code and skipped: the two modes have divergent snapshot/apply/restore semantics (solo snapshots one sound and pauses others without deselecting; Quick Mix snapshots all and deselects everything), so a shared abstraction would be a forced special-general mixture for pure internal dedup of working, device-only-verifiable audio code. The spike's own default recommendation is to skip it unless a new surface forces the cost to bite again.